### PR TITLE
Support request batching

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -74,12 +74,13 @@ func MetricsHandler() http.Handler {
 }
 
 // RecordRequest records metrics for a request
-func RecordRequest(endpoint, provider, transport, method string, duration float64, failed bool) {
+func RecordRequest(endpoint, provider, transport, method string, duration float64) {
 	requestsTotal.WithLabelValues(endpoint, provider, transport, method).Inc()
-	if failed {
-		failedRequestsTotal.WithLabelValues(endpoint, provider, transport, method).Inc()
-	}
 	requestDuration.WithLabelValues(endpoint, provider, transport, method).Observe(duration)
+}
+
+func RecordFailedRequest(endpoint, provider, transport, method string) {
+	failedRequestsTotal.WithLabelValues(endpoint, provider, transport, method).Inc()
 }
 
 func RecordOpenConnection(endpoint, provider string) {

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -23,6 +23,8 @@ type Provider struct {
 	Http         string `yaml:"http"`
 	Ws           string `yaml:"ws"`
 
+	Headers map[string]string `yaml:"headers,omitempty"`
+
 	// The timeout for the provider. Use Endpoint.GetTimeout() to get the actual timeout
 	Timeout time.Duration `yaml:"timeout,omitempty"`
 
@@ -130,17 +132,17 @@ func (e *Provider) Healthcheck(p *Endpoint) error {
 	ctx := context.Background()
 
 	fn := func(ctx context.Context, req *rpc.Request, errRpcError bool) (*rpc.Response, error) {
-		res, err := SendHTTPRPCRequest(ctx, e, req)
+		res, err := SendHTTPRPCRequest(ctx, e, rpc.NewBatchRequest(req))
 		if err != nil {
 			return nil, err
 		}
 
-		if errRpcError && res.IsError() {
-			_, err := res.GetError()
+		if errRpcError && res.Responses[0].IsError() {
+			_, err := res.Responses[0].GetError()
 			return nil, err
 		}
 
-		return res, nil
+		return res.Responses[0], nil
 	}
 
 	switch p.Kind {

--- a/internal/provider_test.go
+++ b/internal/provider_test.go
@@ -70,7 +70,10 @@ func TestRateLimitWithRetryAfter(t *testing.T) {
 	}
 
 	// Send a request that will trigger rate limiting
-	_, _, err := ProxyHTTP(context.Background(), provider, rpc.NewRequest("1", "eth_blockNumber", []interface{}{}), &servertiming.Header{})
+	req := rpc.NewBatchRequest(
+		rpc.NewRequest("1", "eth_blockNumber", []interface{}{}),
+	)
+	_, _, err := ProxyHTTP(context.Background(), provider, req, &servertiming.Header{})
 
 	// Verify the error and retry time was set correctly
 	assert.Error(t, err)
@@ -126,7 +129,10 @@ func TestSlowProvider(t *testing.T) {
 	timing := &servertiming.Header{}
 
 	// Attempt to proxy a request - it should use the fast provider because the first one is too slow
-	resp, endpoint, err := ProxyHTTP(context.Background(), provider, rpc.NewRequest("1", "eth_blockNumber", []interface{}{}), timing)
+	req := rpc.NewBatchRequest(
+		rpc.NewRequest("1", "eth_blockNumber", []interface{}{}),
+	)
+	resp, endpoint, err := ProxyHTTP(context.Background(), provider, req, timing)
 
 	// Verify we got a response
 	assert.NoError(t, err)
@@ -166,7 +172,10 @@ func TestNonRespondingProvider(t *testing.T) {
 
 	// Attempt to use the non-responding provider first
 	timing := &servertiming.Header{}
-	resp, endpoint, err := ProxyHTTP(context.Background(), provider, rpc.NewRequest("1", "eth_blockNumber", []interface{}{}), timing)
+	req := rpc.NewBatchRequest(
+		rpc.NewRequest("1", "eth_blockNumber", []interface{}{}),
+	)
+	resp, endpoint, err := ProxyHTTP(context.Background(), provider, req, timing)
 
 	// Verify we got a response from the working provider
 	assert.NoError(t, err)

--- a/internal/rpc/batch.go
+++ b/internal/rpc/batch.go
@@ -1,0 +1,150 @@
+package rpc
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type BatchResponse struct {
+	Responses []*Response
+	IsBatch   bool
+}
+
+var _ json.Unmarshaler = &BatchResponse{}
+var _ json.Marshaler = &BatchResponse{}
+
+func NewBatchResponse(res ...*Response) *BatchResponse {
+	return &BatchResponse{
+		Responses: res,
+		IsBatch:   len(res) > 1,
+	}
+}
+
+// UnmarshalJSON for a batch request supports decoding a single request as well
+func (r *BatchResponse) UnmarshalJSON(b []byte) error {
+	switch b[0] {
+	case '[':
+		var res []*Response
+		err := json.Unmarshal(b, &res)
+		if err != nil {
+			return err
+		}
+		r.Responses = res
+		r.IsBatch = true
+		return nil
+	case '{':
+		var res Response
+		err := json.Unmarshal(b, &res)
+		if err != nil {
+			return err
+		}
+		r.Responses = []*Response{&res}
+		r.IsBatch = false
+		return nil
+	}
+
+	return fmt.Errorf("invalid request: %s", FormatRawBody(string(b)))
+}
+
+// MarshalJSON will encode a single (non batched) request to a single object or multiple requests into an array
+func (r BatchResponse) MarshalJSON() ([]byte, error) {
+	if len(r.Responses) == 0 {
+		return nil, fmt.Errorf("empty batch response")
+	}
+
+	// If the batch is just one single request then unbatch it
+	if !r.IsBatch {
+		return json.Marshal(r.Responses[0])
+	}
+
+	return json.Marshal(r.Responses)
+}
+
+type BatchRequest struct {
+	Requests []*Request
+	IsBatch  bool
+}
+
+var _ json.Unmarshaler = &BatchRequest{}
+var _ json.Marshaler = &BatchRequest{}
+
+func NewBatchRequest(req ...*Request) *BatchRequest {
+	return &BatchRequest{
+		Requests: req,
+		IsBatch:  len(req) > 1,
+	}
+}
+
+// UnmarshalJSON for a batch request supports decoding a single request as well
+func (r *BatchRequest) UnmarshalJSON(b []byte) error {
+	switch b[0] {
+	case '[':
+		var req []*Request
+		err := json.Unmarshal(b, &req)
+		if err != nil {
+			return err
+		}
+		r.Requests = req
+		r.IsBatch = true
+		return nil
+	case '{':
+		var req Request
+		err := json.Unmarshal(b, &req)
+		if err != nil {
+			return err
+		}
+		r.Requests = []*Request{&req}
+		r.IsBatch = false
+		return nil
+	}
+
+	return fmt.Errorf("invalid request: %s", FormatRawBody(string(b)))
+}
+
+// MarshalJSON will encode a single (non batched) request to a single object or multiple requests into an array
+func (r BatchRequest) MarshalJSON() ([]byte, error) {
+	if len(r.Requests) == 0 {
+		return nil, fmt.Errorf("empty batch request")
+	}
+
+	// If the batch is just one single request then unbatch it
+	if !r.IsBatch {
+		return json.Marshal(r.Requests[0])
+	}
+
+	return json.Marshal(r.Requests)
+}
+
+func DecodeBatchRequest(b []byte) (*BatchRequest, error) {
+	var batch BatchRequest
+	err := json.Unmarshal(b, &batch)
+	if err != nil {
+		return nil, err
+	}
+	return &batch, nil
+}
+
+func DecodeBatchResponse(b []byte) (*BatchResponse, error) {
+	var batch BatchResponse
+	err := json.Unmarshal(b, &batch)
+	if err != nil {
+		return nil, err
+	}
+	return &batch, nil
+}
+
+func SerializeBatchRequest(req *BatchRequest) []byte {
+	b, err := json.Marshal(req)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func SerializeBatchResponse(res *BatchResponse) []byte {
+	b, err := json.Marshal(res)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/internal/rpc/batch_test.go
+++ b/internal/rpc/batch_test.go
@@ -1,0 +1,79 @@
+package rpc
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Incoming single request should be serialized as a single object
+func TestNoBatchRequest(t *testing.T) {
+	req := BatchRequest{}
+	err := json.Unmarshal([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["0x1", false]}`), &req)
+	if err != nil {
+		t.Fatalf("error unmarshalling batch request: %v", err)
+	}
+
+	if req.IsBatch {
+		t.Fatalf("single request IsBatch=true")
+	}
+
+	b := SerializeBatchRequest(&req)
+	if b[0] != '{' {
+		t.Fatalf("expected single request to be serialized as a single object")
+	}
+}
+
+func TestBatchRequest(t *testing.T) {
+	req := BatchRequest{}
+	err := json.Unmarshal([]byte(`[{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["0x1", false]},{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["0x1", false]}]`), &req)
+	if err != nil {
+		t.Fatalf("error unmarshalling batch request: %v", err)
+	}
+
+	if !req.IsBatch {
+		t.Fatalf("batch request IsBatch=false")
+	}
+
+	if len(req.Requests) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(req.Requests))
+	}
+
+	b := SerializeBatchRequest(&req)
+	if b[0] != '[' {
+		t.Fatalf("expected batch request to be serialized as an array")
+	}
+}
+
+func TestNoBatchResponse(t *testing.T) {
+	res := BatchResponse{}
+	err := json.Unmarshal([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x1"}`), &res)
+	if err != nil {
+		t.Fatalf("error unmarshalling batch response: %v", err)
+	}
+
+	if res.IsBatch {
+		t.Fatalf("single response IsBatch=true")
+	}
+
+	b := SerializeBatchResponse(&res)
+	if b[0] != '{' {
+		t.Fatalf("expected single response to be serialized as a single object")
+	}
+}
+
+func TestBatchResponse(t *testing.T) {
+	res := BatchResponse{}
+	err := json.Unmarshal([]byte(`[{"jsonrpc":"2.0","id":1,"result":"0x1"}]`), &res)
+	if err != nil {
+		t.Fatalf("error unmarshalling batch response: %v", err)
+	}
+
+	if !res.IsBatch {
+		t.Fatalf("batch response IsBatch=false")
+	}
+
+	b := SerializeBatchResponse(&res)
+	if b[0] != '[' {
+		t.Fatalf("expected batch response to be serialized as an array")
+	}
+}

--- a/internal/rpc/request.go
+++ b/internal/rpc/request.go
@@ -1,6 +1,8 @@
 package rpc
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 type Request struct {
 	Version string `json:"jsonrpc"`
@@ -18,15 +20,6 @@ func NewRequest(id string, method string, params any) *Request {
 	}
 }
 
-func SerializeRequest(req *Request) []byte {
-	b, err := json.Marshal(req)
-	if err != nil {
-		panic(err)
-	}
-
-	return b
-}
-
 func DecodeRequest(b []byte) (*Request, error) {
 	var req Request
 	err := json.Unmarshal(b, &req)
@@ -35,4 +28,16 @@ func DecodeRequest(b []byte) (*Request, error) {
 	}
 
 	return &req, nil
+}
+
+func SerializeRequest(req *Request) []byte {
+	b, err := json.Marshal(req)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func (r *Request) GetID() string {
+	return GetRequestIDString(r.ID)
 }

--- a/internal/rpc/response.go
+++ b/internal/rpc/response.go
@@ -9,11 +9,13 @@ type Response struct {
 	Version string `json:"jsonrpc"`
 
 	// ID might be a string or number
-	ID     any    `json:"id,omitempty"`
-	Result any    `json:"result"`
-	Method string `json:"method,omitempty"`
-	Params any    `json:"params,omitempty"`
-	Error  any    `json:"error,omitempty"`
+	ID     any `json:"id,omitempty"`
+	Result any `json:"result"`
+	Error  any `json:"error,omitempty"`
+}
+
+func (r *Response) GetID() string {
+	return GetRequestIDString(r.ID)
 }
 
 func (r *Response) IsError() bool {
@@ -26,13 +28,13 @@ func (r *Response) GetError() (int, error) {
 		return 0, fmt.Errorf("unable to parse error: %v", r.Error)
 	}
 
-	errorCode := err["code"].(float64)
+	errorCode, _ := err["code"].(float64)
 
 	return int(errorCode), fmt.Errorf("%d %s", int(errorCode), err["message"])
 }
 
-func SerializeResponse(req *Response) []byte {
-	b, err := json.Marshal(req)
+func SerializeResponse(res *Response) []byte {
+	b, err := json.Marshal(res)
 
 	if err != nil {
 		panic(err)

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -8,6 +8,8 @@ import (
 
 type ReaderFunc func(ctx context.Context, req *Request, errRpcError bool) (*Response, error)
 
+var BatchIDCounter = 0
+
 // GetRequestIDString returns the request ID as a string.
 // The request ID is commonly a number, but might be a string with a number or a string.
 func GetRequestIDString(id any) string {


### PR DESCRIPTION
Fully support request batching for HTTP

For websockets, the incoming batch will be sent as individual messages to the upstream