### PR TITLE
Add HTTP request coalescing (in-flight deduplication)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Providers are tried in priority order; an unhealthy one is taken out of rotation
 - **Traffic Observability**: Monitor and analyze your RPC traffic patterns
 - **Request Validation**: Validates requests and responses to detect errors
 - **Rate Limit Handling**: Detects rate limits and retries once the provider is available again
-- **Request Coalescing**: Collapses identical concurrent read requests into a single upstream call and fans the response back to every caller
+- **Request Coalescing**: Collapses identical concurrent read requests into a single upstream call and fans the response back to every client
 - **Connection Optimization**: Upstream keepalive/http2 connection pooling
 - **Health Checks**: Automatic health monitoring of all configured providers
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Providers are tried in priority order; an unhealthy one is taken out of rotation
 - **Traffic Observability**: Monitor and analyze your RPC traffic patterns
 - **Request Validation**: Validates requests and responses to detect errors
 - **Rate Limit Handling**: Detects rate limits and retries once the provider is available again
+- **Request Coalescing**: Collapses identical concurrent read requests into a single upstream call and fans the response back to every caller
 - **Connection Optimization**: Upstream keepalive/http2 connection pooling
 - **Health Checks**: Automatic health monitoring of all configured providers
 
@@ -51,6 +52,20 @@ Providers are tried in priority order; an unhealthy one is taken out of rotation
 
 - Response caching
 - Transaction broadcasts to multiple nodes
+
+### Request coalescing
+
+When several clients send the **same** read request at the same time, haprovider
+issues a single upstream call and returns that one response to all of them. This
+cuts redundant load on your providers and reduces rate-limit (429) exposure under
+bursty traffic, for example many clients polling `eth_getTransactionReceipt` for
+the same hash.
+
+Coalescing is automatic on the HTTP JSON-RPC path and only applies to an
+allowlist of read-only, idempotent methods per chain; transaction submission,
+filters, subscriptions and other stateful calls are always sent individually.
+Batch requests are never coalesced. The `haprovider_coalesced_requests_total`
+metric tracks how many requests were served from a shared upstream call.
 
 ## Installation
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/mitchellh/go-server-timing v1.0.1
 	github.com/prometheus/client_golang v1.21.1
 	github.com/stretchr/testify v1.10.0
+	golang.org/x/sync v0.22.0
 	golang.org/x/term v0.44.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=

--- a/internal/chain/btc/btc.go
+++ b/internal/chain/btc/btc.go
@@ -19,6 +19,27 @@ var genesisBlocks = map[string]string{
 
 type Chain struct{}
 
+// coalesceable is the allowlist of Bitcoin RPC methods that are safe to collapse
+// into a single upstream call. Anything not listed is not coalesced.
+var coalesceable = map[string]struct{}{
+	"getblock":          {},
+	"getblockhash":      {},
+	"getblockheader":    {},
+	"getblockcount":     {},
+	"getblockchaininfo": {},
+	"getrawtransaction": {},
+	"getnetworkinfo":    {},
+	"getmempoolinfo":    {},
+	"gettxout":          {},
+	"estimatesmartfee":  {},
+}
+
+// Coalesceable reports whether identical concurrent Bitcoin RPC calls may be deduplicated.
+func (c *Chain) Coalesceable(method string) bool {
+	_, ok := coalesceable[method]
+	return ok
+}
+
 type networkInfo struct {
 	Subversion string `json:"subversion"`
 }

--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -36,6 +36,11 @@ type Chain interface {
 
 	// ParseErrorResponse parses the error response from the provider and returns an error if the error should set the provider as unhealthy.
 	HandleError(code int, message string) error
+
+	// Coalesceable reports whether identical concurrent calls to this method may
+	// be collapsed into a single upstream request (in-flight deduplication).
+	// Default-deny: only methods on the chain's read-only allowlist return true.
+	Coalesceable(method string) bool
 }
 
 var (

--- a/internal/chain/eth/eth.go
+++ b/internal/chain/eth/eth.go
@@ -38,6 +38,43 @@ func (c *Ethereum) HandleError(code int, message string) error {
 	return nil
 }
 
+func (c *Ethereum) Coalesceable(method string) bool {
+	return Coalesceable(method)
+}
+
+// coalesceable is the allowlist of EVM JSON-RPC methods that are safe to collapse
+// into a single upstream call (read-only and idempotent). Anything not listed is
+// not coalesced. Shared by the Ethereum and Tron chains (Tron speaks EVM JSON-RPC).
+var coalesceable = map[string]struct{}{
+	"eth_call":                  {},
+	"eth_getBalance":            {},
+	"eth_getCode":               {},
+	"eth_getStorageAt":          {},
+	"eth_getTransactionByHash":  {},
+	"eth_getTransactionReceipt": {},
+	"eth_getBlockByNumber":      {},
+	"eth_getBlockByHash":        {},
+	"eth_getBlockReceipts":      {},
+	"eth_getLogs":               {},
+	"eth_getTransactionCount":   {},
+	"eth_estimateGas":           {},
+	"eth_gasPrice":              {},
+	"eth_feeHistory":            {},
+	"eth_maxPriorityFeePerGas":  {},
+	"eth_blockNumber":           {},
+	"eth_chainId":               {},
+	"net_version":               {},
+	"web3_clientVersion":        {},
+}
+
+// Coalesceable reports whether identical concurrent calls to an EVM JSON-RPC
+// method may be deduplicated into a single upstream request. Exported so the
+// Tron chain (which speaks the EVM JSON-RPC surface) can reuse the same policy.
+func Coalesceable(method string) bool {
+	_, ok := coalesceable[method]
+	return ok
+}
+
 func (c Ethereum) ValidateConfig(e *core.Endpoint) error {
 	if e.ChainID != "" {
 		_, err := strconv.ParseUint(e.ChainID, 10, 64)

--- a/internal/chain/solana/solana.go
+++ b/internal/chain/solana/solana.go
@@ -31,6 +31,31 @@ func (c *Chain) ValidateConfig(e *core.Endpoint) error {
 	return nil
 }
 
+// coalesceable is the allowlist of Solana JSON-RPC methods that are safe to
+// collapse into a single upstream call. Anything not listed is not coalesced.
+var coalesceable = map[string]struct{}{
+	"getAccountInfo":         {},
+	"getMultipleAccounts":    {},
+	"getBalance":             {},
+	"getBlock":               {},
+	"getBlockHeight":         {},
+	"getSlot":                {},
+	"getTransaction":         {},
+	"getSignatureStatuses":   {},
+	"getLatestBlockhash":     {},
+	"getEpochInfo":           {},
+	"getVersion":             {},
+	"getGenesisHash":         {},
+	"getHealth":              {},
+	"getTokenAccountBalance": {},
+}
+
+// Coalesceable reports whether identical concurrent Solana calls may be deduplicated.
+func (c *Chain) Coalesceable(method string) bool {
+	_, ok := coalesceable[method]
+	return ok
+}
+
 func (c *Chain) HandleError(code int, message string) error {
 	switch code {
 	// Node is unhealthy / behind by slots

--- a/internal/chain/tron/tron.go
+++ b/internal/chain/tron/tron.go
@@ -33,6 +33,12 @@ func (c *Chain) HandleError(code int, message string) error {
 	return nil
 }
 
+// Coalesceable delegates to the shared EVM policy: Tron speaks the EVM
+// JSON-RPC surface, so the same stateful/non-idempotent methods are excluded.
+func (c *Chain) Coalesceable(method string) bool {
+	return eth.Coalesceable(method)
+}
+
 // Healthcheck batches the node-info RPCs (client version, chain id, block
 // height). Tron has no custom healthcheck beyond the node info. The returned
 // NodeInfo is populated with everything parsed so far, even when an error is

--- a/internal/coalesce_bench_test.go
+++ b/internal/coalesce_bench_test.go
@@ -1,0 +1,100 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	servertiming "github.com/mitchellh/go-server-timing"
+	"github.com/wille/haprovider/internal/core"
+	"github.com/wille/haprovider/internal/rpc"
+)
+
+// BenchmarkCoalescing compares a burst of N concurrent identical requests when
+// the method is coalesceable (eth_call) versus not (eth_sendRawTransaction).
+// Both run the exact same handler; the only difference is whether the requests
+// collapse into one upstream call. The upstream is given a small latency so all
+// N requests overlap in flight (the window coalescing acts on).
+//
+// The headline metric is "upstream-calls/op": ~1 when coalesced, ~N when not.
+func BenchmarkCoalescing(b *testing.B) {
+	const (
+		concurrency  = 32
+		upstreamWait = 2 * time.Millisecond
+	)
+
+	cases := []struct {
+		name   string
+		method string
+		params string
+	}{
+		{"coalesced", "eth_call", `[{"to":"0x0"},"latest"]`},
+		{"uncoalesced", "eth_sendRawTransaction", `["0xsigned"]`},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			var upstream atomic.Int64
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				upstream.Add(1)
+				time.Sleep(upstreamWait)
+				body, _ := io.ReadAll(r.Body)
+				batch, _ := rpc.DecodeBatchRequest(body)
+				resps := make([]*rpc.Response, 0, len(batch.Requests))
+				for _, req := range batch.Requests {
+					resps = append(resps, &rpc.Response{Version: "2.0", ID: req.ID, Result: []byte(`"0xresult"`)})
+				}
+				out, _ := rpc.SerializeBatchResponse(&rpc.BatchResponse{Responses: resps, IsBatch: batch.IsBatch})
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write(out)
+			}))
+			b.Cleanup(srv.Close)
+
+			ep := &core.Endpoint{Name: "test", ChainID: "1", Kind: core.KindEth}
+			p := &core.Provider{Name: "p", Http: srv.URL, Endpoint: ep}
+			ep.Providers = []*core.Provider{p}
+			p.MarkHealthy(0)
+
+			body := func(i int) string {
+				return fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":%q,"params":%s}`, i, tc.method, tc.params)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				fireBurst(ep, concurrency, body)
+			}
+			b.StopTimer()
+
+			b.ReportMetric(float64(upstream.Load())/float64(b.N), "upstream-calls/op")
+		})
+	}
+}
+
+// fireBurst sends n identical concurrent requests through the handler, released
+// together so they overlap in flight, and waits for all to complete.
+func fireBurst(ep *core.Endpoint, n int, body func(i int) string) {
+	var wg sync.WaitGroup
+	release := make(chan struct{})
+	wg.Add(n)
+	for i := range n {
+		go func(i int) {
+			defer wg.Done()
+			r := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(body(i)))
+			r.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			<-release
+			IncomingHttpRpcHandler(context.Background(), ep, w, r, &servertiming.Header{})
+		}(i)
+	}
+	close(release)
+	wg.Wait()
+}

--- a/internal/coalesce_test.go
+++ b/internal/coalesce_test.go
@@ -1,0 +1,162 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	servertiming "github.com/mitchellh/go-server-timing"
+	"github.com/stretchr/testify/assert"
+	"github.com/wille/haprovider/internal/core"
+	"github.com/wille/haprovider/internal/rpc"
+)
+
+// countingUpstream returns an eth endpoint backed by a mock upstream that counts
+// how many HTTP requests it receives, sleeps for delay (to force concurrent
+// requests to overlap), and echoes each JSON-RPC request's id with the mapped
+// result.
+func countingUpstream(t *testing.T, delay time.Duration, methods map[string]any) (*core.Endpoint, *atomic.Int64) {
+	var hits atomic.Int64
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		if delay > 0 {
+			time.Sleep(delay)
+		}
+
+		b, _ := io.ReadAll(r.Body)
+		batch, err := rpc.DecodeBatchRequest(b)
+		if err != nil || len(batch.Requests) == 0 {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		responses := make([]*rpc.Response, 0, len(batch.Requests))
+		for _, req := range batch.Requests {
+			res := &rpc.Response{Version: "2.0", ID: req.ID}
+			if result, ok := methods[req.Method]; ok {
+				res.Result, _ = json.Marshal(result)
+			} else {
+				res.Error = rpc.NewError(-32601, "method not found: "+req.Method)
+			}
+			responses = append(responses, res)
+		}
+
+		out, _ := rpc.SerializeBatchResponse(&rpc.BatchResponse{Responses: responses, IsBatch: batch.IsBatch})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(out)
+	}))
+	t.Cleanup(srv.Close)
+
+	ep := &core.Endpoint{Name: "test", ChainID: "1", Kind: core.KindEth}
+	p := &core.Provider{Name: "p", Http: srv.URL, Endpoint: ep}
+	ep.Providers = []*core.Provider{p}
+	p.MarkHealthy(0)
+	return ep, &hits
+}
+
+// fireConcurrent sends n requests (built by body(i)) at the endpoint concurrently,
+// releasing them all at once, and returns the recorders in order.
+func fireConcurrent(ep *core.Endpoint, n int, body func(i int) string) []*httptest.ResponseRecorder {
+	recorders := make([]*httptest.ResponseRecorder, n)
+	release := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range n {
+		go func(i int) {
+			defer wg.Done()
+			r := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(body(i)))
+			r.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			<-release
+			IncomingHttpRpcHandler(context.Background(), ep, w, r, &servertiming.Header{})
+			recorders[i] = w
+		}(i)
+	}
+	close(release)
+	wg.Wait()
+	return recorders
+}
+
+// TestCoalesce_ConcurrentIdenticalReads: N identical concurrent read requests
+// collapse into a single upstream call, and every client gets a correct response
+// with its own JSON-RPC id echoed back.
+func TestCoalesce_ConcurrentIdenticalReads(t *testing.T) {
+	ep, hits := countingUpstream(t, 150*time.Millisecond, map[string]any{"eth_call": "0xdeadbeef"})
+
+	const n = 20
+	recorders := fireConcurrent(ep, n, func(i int) string {
+		return fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"eth_call","params":["x"]}`, i)
+	})
+
+	assert.Equal(t, int64(1), hits.Load(), "identical concurrent reads should collapse to one upstream call")
+
+	for i, w := range recorders {
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "0xdeadbeef")
+		assert.Contains(t, w.Body.String(), fmt.Sprintf(`"id":%d`, i), "each client must get its own id echoed")
+	}
+}
+
+// TestCoalesce_UnsafeMethodNotCoalesced: identical concurrent writes are NOT
+// coalesced — each must reach the upstream independently.
+func TestCoalesce_UnsafeMethodNotCoalesced(t *testing.T) {
+	ep, hits := countingUpstream(t, 50*time.Millisecond, map[string]any{"eth_sendRawTransaction": "0xhash"})
+
+	const n = 10
+	recorders := fireConcurrent(ep, n, func(i int) string {
+		return fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"eth_sendRawTransaction","params":["0xsigned"]}`, i)
+	})
+
+	assert.Equal(t, int64(n), hits.Load(), "sendRawTransaction must never be coalesced")
+	for _, w := range recorders {
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "0xhash")
+	}
+}
+
+// TestCoalesce_DifferentParamsNotCoalesced: same method, different params must
+// not share an upstream call.
+func TestCoalesce_DifferentParamsNotCoalesced(t *testing.T) {
+	ep, hits := countingUpstream(t, 100*time.Millisecond, map[string]any{"eth_getBalance": "0x1"})
+
+	const n = 5
+	recorders := fireConcurrent(ep, n, func(i int) string {
+		return fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"eth_getBalance","params":["0xaddr%d"]}`, i, i)
+	})
+
+	assert.Equal(t, int64(n), hits.Load(), "distinct params must not coalesce")
+	for _, w := range recorders {
+		assert.Equal(t, http.StatusOK, w.Code)
+	}
+}
+
+// TestCoalesce_BatchNotCoalesced: batch requests bypass coalescing and behave as
+// before (each reaches the upstream, both sub-results returned).
+func TestCoalesce_BatchNotCoalesced(t *testing.T) {
+	ep, hits := countingUpstream(t, 100*time.Millisecond, map[string]any{
+		"eth_call":       "0xaa",
+		"eth_getBalance": "0xbb",
+	})
+
+	const n = 4
+	recorders := fireConcurrent(ep, n, func(i int) string {
+		return `[{"jsonrpc":"2.0","id":1,"method":"eth_call","params":["x"]},` +
+			`{"jsonrpc":"2.0","id":2,"method":"eth_getBalance","params":["y"]}]`
+	})
+
+	assert.Equal(t, int64(n), hits.Load(), "batches must not be coalesced")
+	for _, w := range recorders {
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "0xaa")
+		assert.Contains(t, w.Body.String(), "0xbb")
+	}
+}

--- a/internal/core/endpoint.go
+++ b/internal/core/endpoint.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+
+	"golang.org/x/sync/singleflight"
 )
 
 // DefaultMaxResponseSize bounds how large an upstream provider response may be
@@ -53,6 +55,10 @@ type Endpoint struct {
 	// mu guards ChainID, which is set/validated concurrently by per-provider
 	// healthcheck goroutines sharing this endpoint.
 	mu sync.Mutex
+
+	// Coalescer deduplicates identical concurrent upstream requests on the HTTP
+	// path. The zero value is ready to use; keys are scoped to this endpoint.
+	Coalescer singleflight.Group
 }
 
 // SetChainID records the chain ID reported by a provider. The first provider to

--- a/internal/http.go
+++ b/internal/http.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -67,6 +68,41 @@ func IncomingHttpRpcHandler(ctx context.Context, endpoint *core.Endpoint, w http
 		ctx = httpx.WithForwardedFor(ctx, r)
 	}
 
+	// Coalesce a single (non-batch) read-only call: identical concurrent requests
+	// share one upstream call. Batches and stateful/non-idempotent methods run
+	// their own request (see chain.Coalesceable).
+	c := chain.New(endpoint.Kind)
+	if !req.IsBatch && len(req.Requests) == 1 && c != nil && c.Coalesceable(req.Requests[0].Method) {
+		coalesceRequest(ctx, endpoint, req, timing, log, w)
+		return
+	}
+
+	result, err := forwardWithFailover(ctx, endpoint, req, timing, log)
+	if err != nil {
+		writeForwardError(w, err, log)
+		return
+	}
+	writeBatchResponse(w, endpoint, result.provider, result.res, log)
+}
+
+// forwardResult is the outcome of a successful failover: the upstream response
+// and the provider that served it. It is shared verbatim between coalesced
+// callers, so callers must not mutate its response before writing.
+type forwardResult struct {
+	res      *rpc.BatchResponse
+	provider *core.Provider
+}
+
+// errNoProvidersAvailable is returned by forwardWithFailover when every provider
+// is offline or has failed the request.
+var errNoProvidersAvailable = errors.New("no providers available")
+
+// forwardWithFailover runs the provider failover loop for req and returns the
+// first successful response and the provider that produced it. It records
+// per-request metrics and marks providers unhealthy on failure. It returns
+// ctx.Err() if the context is cancelled mid-flight, or errNoProvidersAvailable
+// when no provider could serve the request.
+func forwardWithFailover(ctx context.Context, endpoint *core.Endpoint, req *rpc.BatchRequest, timing *servertiming.Header, log *slog.Logger) (*forwardResult, error) {
 NextProvider:
 	for _, provider := range endpoint.Providers {
 		if !provider.IsOnline() {
@@ -79,10 +115,11 @@ NextProvider:
 		res, err := httpx.SendRPCBatchRequest(ctx, provider, req)
 		m.Stop()
 
-		// Client connection closed
+		// Client connection closed (or, for a coalesced call, the detached
+		// context — which never cancels).
 		select {
 		case <-ctx.Done():
-			return
+			return nil, ctx.Err()
 		default:
 		}
 
@@ -98,12 +135,11 @@ NextProvider:
 			continue NextProvider
 		}
 
-		log = log.With("provider", provider.Name, "request_time", time.Since(start).String())
-
+		reqLog := log.With("provider", provider.Name, "request_time", time.Since(start).String())
 		if req.IsBatch {
-			log.Debug("batch request", "size", len(req.Requests))
+			reqLog.Debug("batch request", "size", len(req.Requests))
 		} else {
-			log.Debug("request", "method", req.Requests[0].Method)
+			reqLog.Debug("request", "method", req.Requests[0].Method)
 		}
 
 		// Record one metric per (sub-)request, labeled by method, like the WS path.
@@ -117,51 +153,105 @@ NextProvider:
 			}
 		}
 
-		for _, res := range res.Responses {
-			if res.IsError() {
-				errorCode, errorMessage := res.GetError()
-				log.Debug("error response", "error_code", errorCode, "error_message", errorMessage)
+		for _, sub := range res.Responses {
+			if sub.IsError() {
+				errorCode, errorMessage := sub.GetError()
+				reqLog.Debug("error response", "error_code", errorCode, "error_message", errorMessage)
 
-				err := chain.New(endpoint.Kind).HandleError(errorCode, errorMessage.Error())
-
-				if err != nil {
-					provider.MarkUnhealthy(err)
+				if herr := chain.New(endpoint.Kind).HandleError(errorCode, errorMessage.Error()); herr != nil {
+					provider.MarkUnhealthy(herr)
 					continue NextProvider
 				}
 			}
 		}
 
 		if req.IsBatch && len(res.Responses) != len(req.Requests) {
-			log.Error("batch response size mismatch", "request_size", len(req.Requests), "response_size", len(res.Responses))
+			reqLog.Error("batch response size mismatch", "request_size", len(req.Requests), "response_size", len(res.Responses))
 			provider.MarkUnhealthy(fmt.Errorf("batch response size mismatch"))
 			continue NextProvider
 		}
 
-		if !endpoint.Public {
-			w.Header().Set("X-Provider", provider.Name)
-		}
+		return &forwardResult{res: res, provider: provider}, nil
+	}
 
-		out, err := rpc.SerializeBatchResponse(res)
-		if err != nil {
-			log.Error("error serializing response", "error", err)
-			http.Error(w, "error serializing response", http.StatusInternalServerError)
+	return nil, errNoProvidersAvailable
+}
+
+// coalesceRequest routes a single coalesceable request through the endpoint's
+// singleflight group so identical concurrent requests share one upstream call,
+// then writes the shared response to this client with its own JSON-RPC id.
+func coalesceRequest(ctx context.Context, endpoint *core.Endpoint, req *rpc.BatchRequest, timing *servertiming.Header, log *slog.Logger, w http.ResponseWriter) {
+	// id is excluded from the key: it varies per client. Params is raw JSON, so
+	// only byte-identical params collapse (a safe, if occasionally conservative, key).
+	key := req.Requests[0].Method + "\x00" + string(req.Requests[0].Params)
+
+	ch := endpoint.Coalescer.DoChan(key, func() (any, error) {
+		// Detached context: one client disconnecting must not cancel the shared
+		// upstream call the other coalesced callers are waiting on. It stays bounded
+		// by the per-provider timeout inside httpx, and preserves ctx values (XFF).
+		return forwardWithFailover(context.WithoutCancel(ctx), endpoint, req, timing, log)
+	})
+
+	select {
+	case <-ctx.Done():
+		// This client left; the shared work continues for the others.
+		return
+	case sf := <-ch:
+		if sf.Shared {
+			metrics.RecordCoalescedRequest(endpoint.Name, req.Requests[0].Method)
+		}
+		if sf.Err != nil {
+			writeForwardError(w, sf.Err, log)
 			return
 		}
 
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		shared := sf.Val.(*forwardResult)
+		// Value-copy the shared response and stamp this client's id onto the copy;
+		// concurrent callers must never mutate the shared *rpc.Response.
+		resp := *shared.res.Responses[0]
+		resp.ID = req.Requests[0].ID
+		writeBatchResponse(w, endpoint, shared.provider, rpc.NewBatchResponse(&resp), log)
+	}
+}
 
-		if _, err := w.Write(out); err != nil {
-			log.Error("error writing body", "error", err)
-		}
-
+// writeForwardError writes the appropriate client response for a failover error.
+func writeForwardError(w http.ResponseWriter, err error, log *slog.Logger) {
+	// Client disconnected mid-flight: nothing left to write to.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return
 	}
 
-	log.Error("no providers available")
+	if errors.Is(err, errNoProvidersAvailable) {
+		log.Error("no providers available")
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		if werr := rpc.WriteResponse(w, &rpc.ErrorResponseNoProvidersAvailable); werr != nil {
+			log.Error("error writing body", "error", werr)
+		}
+		return
+	}
+
+	log.Error("request failed", "error", err)
+	http.Error(w, "request failed", http.StatusInternalServerError)
+}
+
+// writeBatchResponse serializes res and writes it to the client, setting the
+// X-Provider header (unless the endpoint is public) and content type.
+func writeBatchResponse(w http.ResponseWriter, endpoint *core.Endpoint, provider *core.Provider, res *rpc.BatchResponse, log *slog.Logger) {
+	if !endpoint.Public {
+		w.Header().Set("X-Provider", provider.Name)
+	}
+
+	out, err := rpc.SerializeBatchResponse(res)
+	if err != nil {
+		log.Error("error serializing response", "error", err)
+		http.Error(w, "error serializing response", http.StatusInternalServerError)
+		return
+	}
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(http.StatusServiceUnavailable)
-	if err := rpc.WriteResponse(w, &rpc.ErrorResponseNoProvidersAvailable); err != nil {
+
+	if _, err := w.Write(out); err != nil {
 		log.Error("error writing body", "error", err)
 	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -69,6 +69,16 @@ var (
 		},
 		[]string{"endpoint", "transport"},
 	)
+
+	// Requests served from a coalesced (deduplicated) upstream call rather than
+	// their own upstream request.
+	coalescedRequests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "haprovider_coalesced_requests_total",
+			Help: "Total number of requests served from a coalesced upstream call",
+		},
+		[]string{"endpoint", "method"},
+	)
 )
 
 // MetricsHandler returns an HTTP handler for the Prometheus metrics endpoint
@@ -80,7 +90,14 @@ func MetricsHandler() http.Handler {
 	prometheus.MustRegister(providerHealth)
 	prometheus.MustRegister(requestDuration)
 	prometheus.MustRegister(inflightRequests)
+	prometheus.MustRegister(coalescedRequests)
 	return promhttp.Handler()
+}
+
+// RecordCoalescedRequest records that a request was served from a shared
+// (deduplicated) upstream call instead of issuing its own.
+func RecordCoalescedRequest(endpoint, method string) {
+	coalescedRequests.WithLabelValues(endpoint, method).Inc()
 }
 
 // TrackInflight increments the in-flight gauge and returns a function that


### PR DESCRIPTION
## What

Adds **request coalescing** on the HTTP JSON-RPC path: identical concurrent read requests collapse into a single upstream call, and that one response is fanned back to every caller.

This reduces redundant load on upstream providers and lowers rate-limit (429) exposure under bursty traffic (e.g. many clients polling `eth_getTransactionReceipt` for the same hash).

## How

- **`chain.Chain` gains `Coalesceable(method string) bool`** — a per-chain allowlist of read-only, idempotent methods. The EVM allowlist is shared by `eth` and `tron`; `solana` and `btc` have their own. Default-deny: anything not on the list is sent individually.
- **`core.Endpoint` holds a `singleflight.Group`.** A single coalesceable request runs through it, keyed by `method + params` (the JSON-RPC `id` is excluded since it varies per client).
- **The provider failover loop is extracted into `forwardWithFailover`.** The coalescing leader runs it under a detached context (`context.WithoutCancel`) so one client disconnecting can't cancel the shared upstream call the others are waiting on. Each caller writes a value-copy of the shared response stamped with its own `id` (never mutating the shared response).
- **Batches and non-allowlisted methods bypass coalescing entirely.**
- New `haprovider_coalesced_requests_total{endpoint,method}` metric; README updated.

## Scope / non-goals

- HTTP only. WebSocket coalescing and batch coalescing are out of scope for now.
- Allowlist is deliberately conservative (default-deny): a read method not yet listed simply isn't coalesced until added.

## Testing

- Unit + integration tests in `internal/coalesce_test.go`, driving the real handler concurrently against a hit-counting mock upstream:
  - 20 identical concurrent `eth_call` → **1** upstream hit; every client gets the result with its own id echoed.
  - 10 identical `eth_sendRawTransaction` → **10** hits (never coalesced).
  - Distinct params → not coalesced; batches → not coalesced.
- `go test -race ./...` green (stable across repeated runs); `go vet` and `golangci-lint` clean.