### PR TITLE
Add response caching with a bounded in-memory LRU store

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,39 @@ Providers are tried in priority order; an unhealthy one is taken out of rotation
 - **Traffic Observability**: Monitor and analyze your RPC traffic patterns
 - **Request Validation**: Validates requests and responses to detect errors
 - **Rate Limit Handling**: Detects rate limits and retries once the provider is available again
+- **Response Caching**: Serves repeat reads of immutable data from an in-memory cache instead of the upstream
 - **Connection Optimization**: Upstream keepalive/http2 connection pooling
 - **Health Checks**: Automatic health monitoring of all configured providers
 
+### Response caching
+
+haprovider caches responses to read-only requests whose result does not change,
+so repeat calls (a block by hash, a mined transaction receipt, `eth_chainId`) are
+served locally instead of hitting a provider. This cuts upstream load and
+rate-limit (429) exposure. Caching works on both the HTTP and WebSocket paths and
+is enabled by default on every endpoint using an in-memory store.
+
+Only an allowlist of read-only methods per chain is cached, and only when the
+result is safe to reuse: requests referencing a mutable block tag
+(`latest`/`pending`/`safe`/`finalized`) are never cached, error and null results
+are never cached, and an unconfirmed `eth_getTransactionByHash` (null
+`blockNumber`) is skipped until it is mined. A per-entry TTL bounds reorg
+staleness; set `cache_ttl` per endpoint (a value of `0` disables caching for that
+endpoint). The `haprovider_cache_requests_total` metric tracks hits and misses.
+
+Batch requests are cached per element: cached members are served locally and only
+the uncached members are forwarded upstream, then the responses are merged back in
+order. A batch whose members are all cached is answered without contacting a
+provider.
+
+The default in-memory store is a bounded LRU: it is capped by both a total size
+budget (`cache_max_size_mb`, default 128 MB per endpoint) and an entry count, and
+evicts least-recently-used entries when either limit is reached. Individual
+responses larger than 5 MB are never cached (they pass through to the client), so
+one large payload cannot dominate the cache.
+
 ### *What haprovider doesn't do right now*
 
-- Response caching
 - Transaction broadcasts to multiple nodes
 
 ## Installation
@@ -164,6 +191,8 @@ endpoints:
   - `chainId`: Network chain ID (optional, EVM chains)
   - `block_lag_tolerance`: How many blocks a provider may trail the highest seen tip before it's considered unhealthy (optional, per-chain default)
   - `max_response_size`: Max upstream response size in bytes (optional, default 100MB, 0 = unlimited)
+  - `cache_ttl`: How long cacheable responses are kept (e.g. `10s`, `1m`) (optional, default 10s, 0 = caching disabled)
+  - `cache_max_size_mb`: Total response-cache size budget in MB for this endpoint (optional, default 128)
   - `public`: If this endpoint is available to the public. A public endpoint will not include detailed error messages and headers (optional, default false)
   - `add_xfwd_headers`: Add X-Forwarded-For to upstream requests (optional, default false)
   - `providers`: List of provider configurations

--- a/internal/bench_test.go
+++ b/internal/bench_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	servertiming "github.com/mitchellh/go-server-timing"
+	"github.com/wille/haprovider/internal/cache"
 	"github.com/wille/haprovider/internal/core"
 	"github.com/wille/haprovider/internal/rpctest"
 )
@@ -76,5 +77,37 @@ func BenchmarkIncomingHttpRpcHandler(b *testing.B) {
 				IncomingHttpRpcHandler(context.Background(), ep, w, r, &servertiming.Header{})
 			}
 		})
+	}
+}
+
+// BenchmarkIncomingHttpRpcHandler_CacheHit measures serving a cacheable request
+// entirely from the warm cache, i.e. the path that skips the upstream round-trip.
+// Compare against the "small" case above to see the cache win.
+func BenchmarkIncomingHttpRpcHandler_CacheHit(b *testing.B) {
+	srv := rpctest.NewServer(map[string]any{"eth_getBlockByHash": map[string]string{"hash": "0xabc"}}, nil)
+	b.Cleanup(srv.Close)
+
+	ep := &core.Endpoint{Name: "test", ChainID: "1", Kind: core.KindEth}
+	if err := ep.InitCache(cache.NewMemory(0, 0)); err != nil {
+		b.Fatal(err)
+	}
+	p := &core.Provider{Name: "p", Http: srv.URL, Endpoint: ep}
+	ep.Providers = []*core.Provider{p}
+	p.MarkHealthy(0)
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByHash","params":["0xh",false]}`
+
+	// Warm the cache so every measured iteration is a hit.
+	warm := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(body))
+	warm.Header.Set("Content-Type", "application/json")
+	IncomingHttpRpcHandler(context.Background(), ep, httptest.NewRecorder(), warm, &servertiming.Header{})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		IncomingHttpRpcHandler(context.Background(), ep, w, r, &servertiming.Header{})
 	}
 }

--- a/internal/cache/bench_test.go
+++ b/internal/cache/bench_test.go
@@ -1,0 +1,58 @@
+package cache
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// BenchmarkMemoryGet measures a single-threaded cache hit (the per-request hot
+// path: lookup + LRU move-to-front under the mutex).
+func BenchmarkMemoryGet(b *testing.B) {
+	m := NewMemory(0, 0)
+	ctx := context.Background()
+	_ = m.Set(ctx, "key", make([]byte, 512), time.Hour)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_, _, _ = m.Get(ctx, "key")
+	}
+}
+
+// BenchmarkMemoryGetParallel measures cache-hit throughput under contention: Get
+// takes the full mutex (LRU reordering is a write), so this is the ceiling for
+// concurrent cache reads on one endpoint.
+func BenchmarkMemoryGetParallel(b *testing.B) {
+	m := NewMemory(0, 0)
+	ctx := context.Background()
+	const keys = 1000
+	for i := range keys {
+		_ = m.Set(ctx, "key"+strconv.Itoa(i), make([]byte, 512), time.Hour)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			_, _, _ = m.Get(ctx, "key"+strconv.Itoa(i%keys))
+			i++
+		}
+	})
+}
+
+// BenchmarkMemorySet measures inserts into a byte-bounded cache, exercising the
+// eviction path once the budget is reached.
+func BenchmarkMemorySet(b *testing.B) {
+	m := NewMemory(16*1024*1024, 0)
+	ctx := context.Background()
+	val := make([]byte, 512)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		_ = m.Set(ctx, "key"+strconv.Itoa(i), val, time.Hour)
+	}
+}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,27 @@
+// Package cache provides a pluggable response-cache storage adapter for
+// haprovider, with an in-memory default implementation. The Storage interface is
+// the seam for alternative backends (e.g. Redis) later.
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// Storage is a byte-value cache with per-entry TTL. Implementations must be safe
+// for concurrent use.
+type Storage interface {
+	// Get returns the value for key and whether it was present (and unexpired).
+	Get(ctx context.Context, key string) (value []byte, ok bool, err error)
+
+	// Set stores value under key for the given ttl. A ttl <= 0 is a no-op.
+	Set(ctx context.Context, key string, value []byte, ttl time.Duration) error
+}
+
+// Key builds the cache key for a JSON-RPC request. The request id is excluded
+// (it varies per client); only method and raw params identify the response.
+// Caches are per-endpoint, so the endpoint/chain is not part of the key.
+func Key(method string, params json.RawMessage) string {
+	return method + "\x00" + string(params)
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,165 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestMemory_GetSet(t *testing.T) {
+	m := NewMemory(0, 0)
+	ctx := context.Background()
+
+	if _, ok, _ := m.Get(ctx, "k"); ok {
+		t.Fatal("expected miss on empty cache")
+	}
+
+	_ = m.Set(ctx, "k", []byte("v"), time.Minute)
+	v, ok, _ := m.Get(ctx, "k")
+	if !ok || string(v) != "v" {
+		t.Fatalf("expected hit with v, got ok=%v v=%q", ok, v)
+	}
+}
+
+func TestMemory_Expiry(t *testing.T) {
+	m := NewMemory(0, 0)
+	ctx := context.Background()
+
+	_ = m.Set(ctx, "k", []byte("v"), 20*time.Millisecond)
+	if _, ok, _ := m.Get(ctx, "k"); !ok {
+		t.Fatal("expected hit before expiry")
+	}
+	time.Sleep(40 * time.Millisecond)
+	if _, ok, _ := m.Get(ctx, "k"); ok {
+		t.Fatal("expected miss after expiry")
+	}
+}
+
+func TestMemory_NonPositiveTTLNoOp(t *testing.T) {
+	m := NewMemory(0, 0)
+	ctx := context.Background()
+	_ = m.Set(ctx, "k", []byte("v"), 0)
+	if _, ok, _ := m.Get(ctx, "k"); ok {
+		t.Fatal("ttl<=0 must not store")
+	}
+}
+
+func TestMemory_OversizedNotCached(t *testing.T) {
+	m := NewMemory(0, 0)
+	ctx := context.Background()
+	_ = m.Set(ctx, "k", make([]byte, MaxValueBytes+1), time.Minute)
+	if _, ok, _ := m.Get(ctx, "k"); ok {
+		t.Fatal("values larger than MaxValueBytes must not be cached")
+	}
+	// A value at the limit is cached.
+	_ = m.Set(ctx, "ok", make([]byte, MaxValueBytes), time.Minute)
+	if _, ok, _ := m.Get(ctx, "ok"); !ok {
+		t.Fatal("value at MaxValueBytes should be cached")
+	}
+}
+
+func TestMemory_EvictByEntryCount(t *testing.T) {
+	m := NewMemory(0, 3) // at most 3 entries
+	ctx := context.Background()
+
+	for i := range 5 {
+		_ = m.Set(ctx, strconv.Itoa(i), []byte("v"), time.Minute)
+	}
+	if got := m.Len(); got != 3 {
+		t.Fatalf("expected 3 entries, got %d", got)
+	}
+	// The two oldest (0,1) should be evicted; 2,3,4 remain.
+	for _, k := range []string{"0", "1"} {
+		if _, ok, _ := m.Get(ctx, k); ok {
+			t.Errorf("key %s should have been evicted", k)
+		}
+	}
+	for _, k := range []string{"2", "3", "4"} {
+		if _, ok, _ := m.Get(ctx, k); !ok {
+			t.Errorf("key %s should still be present", k)
+		}
+	}
+}
+
+func TestMemory_EvictByBytes(t *testing.T) {
+	ctx := context.Background()
+	// Budget fits ~3 of these ~1000-byte values.
+	m := NewMemory(3300, 0)
+	val := make([]byte, 1000)
+
+	for i := range 5 {
+		_ = m.Set(ctx, fmt.Sprintf("key-%d", i), val, time.Minute)
+	}
+	if m.Bytes() > 3300 {
+		t.Fatalf("cache exceeded byte budget: %d > 3300", m.Bytes())
+	}
+	if m.Len() > 3 {
+		t.Fatalf("expected at most 3 entries within budget, got %d", m.Len())
+	}
+}
+
+func TestMemory_LRUOrdering(t *testing.T) {
+	m := NewMemory(0, 2)
+	ctx := context.Background()
+
+	_ = m.Set(ctx, "a", []byte("1"), time.Minute)
+	_ = m.Set(ctx, "b", []byte("1"), time.Minute)
+	// Touch "a" so it becomes most-recently-used; adding "c" should evict "b".
+	if _, ok, _ := m.Get(ctx, "a"); !ok {
+		t.Fatal("a should be present")
+	}
+	_ = m.Set(ctx, "c", []byte("1"), time.Minute)
+
+	if _, ok, _ := m.Get(ctx, "b"); ok {
+		t.Error("b should have been evicted as least-recently-used")
+	}
+	if _, ok, _ := m.Get(ctx, "a"); !ok {
+		t.Error("a was recently used and should survive")
+	}
+	if _, ok, _ := m.Get(ctx, "c"); !ok {
+		t.Error("c was just added and should be present")
+	}
+}
+
+func TestMemory_UpdateAdjustsBytes(t *testing.T) {
+	m := NewMemory(0, 0)
+	ctx := context.Background()
+
+	_ = m.Set(ctx, "k", make([]byte, 1000), time.Minute)
+	before := m.Bytes()
+	_ = m.Set(ctx, "k", make([]byte, 10), time.Minute) // shrink same key
+	after := m.Bytes()
+
+	if m.Len() != 1 {
+		t.Fatalf("updating an existing key must not add an entry, len=%d", m.Len())
+	}
+	if after >= before {
+		t.Fatalf("byte accounting not adjusted on update: before=%d after=%d", before, after)
+	}
+}
+
+func TestMemory_Concurrent(t *testing.T) {
+	m := NewMemory(1024*1024, 0)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for g := range 8 {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := range 1000 {
+				k := fmt.Sprintf("g%d-%d", g, i%50)
+				_ = m.Set(ctx, k, []byte("value"), time.Minute)
+				_, _, _ = m.Get(ctx, k)
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	if m.Bytes() > 1024*1024 {
+		t.Fatalf("byte budget exceeded under concurrency: %d", m.Bytes())
+	}
+}

--- a/internal/cache/memory.go
+++ b/internal/cache/memory.go
@@ -1,0 +1,174 @@
+package cache
+
+import (
+	"container/list"
+	"context"
+	"sync"
+	"time"
+)
+
+const (
+	// MaxValueBytes is the largest response that will be cached. Larger responses
+	// (e.g. a full block with all transactions on a high-throughput chain) are
+	// passed through uncached rather than dominating the cache.
+	MaxValueBytes = 5 * 1024 * 1024 // 5 MB
+
+	// DefaultMaxBytes is the default total byte budget for a memory cache.
+	DefaultMaxBytes = 128 * 1024 * 1024 // 128 MB
+
+	// DefaultMaxEntries is the default maximum number of cached entries.
+	DefaultMaxEntries = 50_000
+
+	// janitorInterval is how often expired entries are proactively swept. The
+	// byte/entry bounds cap memory regardless; the janitor just reclaims space
+	// held by expired entries sooner.
+	janitorInterval = time.Minute
+)
+
+type entry struct {
+	key     string
+	value   []byte
+	expires time.Time
+}
+
+// size is the accounted byte cost of the entry (key + value). Map/list overhead
+// per entry is bounded separately by the entry-count limit.
+func (e *entry) size() int64 {
+	return int64(len(e.key) + len(e.value))
+}
+
+// Memory is an in-memory Storage with LRU eviction bounded by both a total byte
+// budget and an entry count. Responses larger than MaxValueBytes are never
+// cached. All operations are O(1) under a single mutex.
+type Memory struct {
+	mu         sync.Mutex
+	maxBytes   int64
+	maxEntries int
+	curBytes   int64
+	ll         *list.List // front = most recently used; element values are *entry
+	items      map[string]*list.Element
+}
+
+// NewMemory returns a bounded LRU cache and starts its janitor. Non-positive
+// maxBytes/maxEntries fall back to DefaultMaxBytes/DefaultMaxEntries.
+func NewMemory(maxBytes int64, maxEntries int) *Memory {
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxBytes
+	}
+	if maxEntries <= 0 {
+		maxEntries = DefaultMaxEntries
+	}
+	m := &Memory{
+		maxBytes:   maxBytes,
+		maxEntries: maxEntries,
+		ll:         list.New(),
+		items:      make(map[string]*list.Element),
+	}
+	go m.janitor()
+	return m
+}
+
+// Len returns the current number of cached entries.
+func (m *Memory) Len() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.ll.Len()
+}
+
+// Bytes returns the current accounted byte usage.
+func (m *Memory) Bytes() int64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.curBytes
+}
+
+func (m *Memory) Get(_ context.Context, key string) ([]byte, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	el, ok := m.items[key]
+	if !ok {
+		return nil, false, nil
+	}
+
+	e := el.Value.(*entry)
+	if time.Now().After(e.expires) {
+		m.removeElement(el)
+		return nil, false, nil
+	}
+
+	m.ll.MoveToFront(el)
+	return e.value, true, nil
+}
+
+func (m *Memory) Set(_ context.Context, key string, value []byte, ttl time.Duration) error {
+	// Skip disabled TTLs and responses too large to cache.
+	if ttl <= 0 || len(value) > MaxValueBytes {
+		return nil
+	}
+
+	// An entry that alone would blow the byte budget is not worth caching (it
+	// would evict everything else to make room for itself).
+	if int64(len(key)+len(value)) > m.maxBytes {
+		return nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	expires := time.Now().Add(ttl)
+
+	if el, ok := m.items[key]; ok {
+		e := el.Value.(*entry)
+		m.curBytes += int64(len(value) - len(e.value))
+		e.value = value
+		e.expires = expires
+		m.ll.MoveToFront(el)
+	} else {
+		e := &entry{key: key, value: value, expires: expires}
+		m.items[key] = m.ll.PushFront(e)
+		m.curBytes += e.size()
+	}
+
+	m.evict()
+	return nil
+}
+
+// evict removes least-recently-used entries until both the byte and entry
+// bounds are satisfied. Caller must hold m.mu.
+func (m *Memory) evict() {
+	for m.curBytes > m.maxBytes || m.ll.Len() > m.maxEntries {
+		el := m.ll.Back()
+		if el == nil {
+			return
+		}
+		m.removeElement(el)
+	}
+}
+
+// removeElement removes el from the list and index and updates the byte total.
+// Caller must hold m.mu.
+func (m *Memory) removeElement(el *list.Element) {
+	e := el.Value.(*entry)
+	m.ll.Remove(el)
+	delete(m.items, e.key)
+	m.curBytes -= e.size()
+}
+
+// janitor periodically removes expired entries.
+func (m *Memory) janitor() {
+	ticker := time.NewTicker(janitorInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		now := time.Now()
+		m.mu.Lock()
+		for el := m.ll.Back(); el != nil; {
+			prev := el.Prev()
+			if now.After(el.Value.(*entry).expires) {
+				m.removeElement(el)
+			}
+			el = prev
+		}
+		m.mu.Unlock()
+	}
+}

--- a/internal/cache_http_test.go
+++ b/internal/cache_http_test.go
@@ -1,0 +1,229 @@
+package internal
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wille/haprovider/internal/cache"
+	"github.com/wille/haprovider/internal/core"
+	"github.com/wille/haprovider/internal/rpc"
+)
+
+// cacheEndpoint builds an eth endpoint with caching enabled, backed by a mock
+// upstream that counts requests and answers each with respond(req).
+func cacheEndpoint(t *testing.T, respond func(*rpc.Request) *rpc.Response) (*core.Endpoint, *atomic.Int64) {
+	var hits atomic.Int64
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		batch, err := rpc.DecodeBatchRequest(b)
+		if err != nil || len(batch.Requests) == 0 {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		resps := make([]*rpc.Response, 0, len(batch.Requests))
+		for _, req := range batch.Requests {
+			hits.Add(1) // count sub-requests that actually reach the upstream
+			resps = append(resps, respond(req))
+		}
+		out, _ := rpc.SerializeBatchResponse(&rpc.BatchResponse{Responses: resps, IsBatch: batch.IsBatch})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(out)
+	}))
+	t.Cleanup(srv.Close)
+
+	ep := &core.Endpoint{Name: "test", ChainID: "1", Kind: core.KindEth}
+	if err := ep.InitCache(cache.NewMemory(0, 0)); err != nil {
+		t.Fatal(err)
+	}
+	p := &core.Provider{Name: "p", Http: srv.URL, Endpoint: ep}
+	ep.Providers = []*core.Provider{p}
+	p.MarkHealthy(0)
+	return ep, &hits
+}
+
+func result(req *rpc.Request, raw string) *rpc.Response {
+	return &rpc.Response{Version: "2.0", ID: req.ID, Result: json.RawMessage(raw)}
+}
+
+// TestCache_HitAfterMiss: a cacheable read misses (one upstream hit) then is
+// served from cache on repeat, with the second caller's own id echoed.
+func TestCache_HitAfterMiss(t *testing.T) {
+	ep, hits := cacheEndpoint(t, func(req *rpc.Request) *rpc.Response {
+		return result(req, `"0xblockdata"`)
+	})
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByHash","params":["0xhash",false]}`
+	w1 := doRPC(ep, body)
+	assert.Equal(t, http.StatusOK, w1.Code)
+	assert.Contains(t, w1.Body.String(), "0xblockdata")
+	assert.Equal(t, int64(1), hits.Load())
+	assert.Empty(t, w1.Header().Get("X-Cache"))
+
+	// Identical request but different id: served from cache, no new upstream hit.
+	w2 := doRPC(ep, `{"jsonrpc":"2.0","id":99,"method":"eth_getBlockByHash","params":["0xhash",false]}`)
+	assert.Equal(t, http.StatusOK, w2.Code)
+	assert.Contains(t, w2.Body.String(), "0xblockdata")
+	assert.Contains(t, w2.Body.String(), `"id":99`)
+	assert.Equal(t, "HIT", w2.Header().Get("X-Cache"))
+	assert.Equal(t, int64(1), hits.Load(), "second identical read must be served from cache")
+}
+
+// TestCache_LatestNotCached: a mutable block tag is never cached.
+func TestCache_LatestNotCached(t *testing.T) {
+	ep, hits := cacheEndpoint(t, func(req *rpc.Request) *rpc.Response {
+		return result(req, `"0xblock"`)
+	})
+	body := `{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["latest",false]}`
+	doRPC(ep, body)
+	doRPC(ep, body)
+	assert.Equal(t, int64(2), hits.Load(), `"latest" params must not be cached`)
+}
+
+// TestCache_NullResultNotCached: a null result (e.g. missing receipt) is not cached.
+func TestCache_NullResultNotCached(t *testing.T) {
+	ep, hits := cacheEndpoint(t, func(req *rpc.Request) *rpc.Response {
+		return result(req, `null`)
+	})
+	body := `{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionReceipt","params":["0xtx"]}`
+	doRPC(ep, body)
+	doRPC(ep, body)
+	assert.Equal(t, int64(2), hits.Load(), "null result must not be cached")
+}
+
+// TestCache_ErrorNotCached: an RPC error response is not cached.
+func TestCache_ErrorNotCached(t *testing.T) {
+	ep, hits := cacheEndpoint(t, func(req *rpc.Request) *rpc.Response {
+		// -32601 is not classified as unhealthy, so it is passed through.
+		return &rpc.Response{Version: "2.0", ID: req.ID, Error: rpc.NewError(-32601, "nope")}
+	})
+	body := `{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByHash","params":["0xhash",false]}`
+	doRPC(ep, body)
+	doRPC(ep, body)
+	assert.Equal(t, int64(2), hits.Load(), "error responses must not be cached")
+}
+
+// TestCache_UnconfirmedTxNotCached: eth_getTransactionByHash with a null
+// blockNumber (pending) is not cached; once confirmed it is.
+func TestCache_UnconfirmedTxNotCached(t *testing.T) {
+	var confirmed atomic.Bool
+	ep, hits := cacheEndpoint(t, func(req *rpc.Request) *rpc.Response {
+		if confirmed.Load() {
+			return result(req, `{"hash":"0xtx","blockNumber":"0x10"}`)
+		}
+		return result(req, `{"hash":"0xtx","blockNumber":null}`)
+	})
+	body := `{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionByHash","params":["0xtx"]}`
+
+	doRPC(ep, body) // pending -> not cached
+	doRPC(ep, body) // still pending -> upstream again
+	assert.Equal(t, int64(2), hits.Load(), "pending tx must not be cached")
+
+	confirmed.Store(true)
+	doRPC(ep, body) // confirmed -> cached now
+	assert.Equal(t, int64(3), hits.Load())
+	doRPC(ep, body) // served from cache
+	assert.Equal(t, int64(3), hits.Load(), "confirmed tx should be cached")
+}
+
+// methodResult answers each sub-request with a JSON string of its own method, so
+// merged batch responses can be checked element by element.
+func methodResult(req *rpc.Request) *rpc.Response {
+	return result(req, `"`+req.Method+`"`)
+}
+
+// decodeBatch decodes a recorder's body as a batch response.
+func decodeBatch(t *testing.T, w *httptest.ResponseRecorder) *rpc.BatchResponse {
+	res, err := rpc.DecodeBatchResponse(w.Body.Bytes())
+	if err != nil {
+		t.Fatalf("decode batch response: %v (body=%s)", err, w.Body.String())
+	}
+	return res
+}
+
+// TestCache_BatchFullyCached: every element of a batch is cached on the first
+// call, so an identical repeat is served entirely from cache.
+func TestCache_BatchFullyCached(t *testing.T) {
+	ep, hits := cacheEndpoint(t, methodResult)
+
+	batch := `[{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByHash","params":["0xh",false]},` +
+		`{"jsonrpc":"2.0","id":2,"method":"eth_getTransactionReceipt","params":["0xt"]}]`
+
+	w1 := doRPC(ep, batch)
+	assert.Equal(t, http.StatusOK, w1.Code)
+	assert.Equal(t, int64(2), hits.Load(), "first batch forwards both sub-requests")
+
+	w2 := doRPC(ep, batch)
+	assert.Equal(t, int64(2), hits.Load(), "identical batch must be fully served from cache")
+	assert.Equal(t, "HIT", w2.Header().Get("X-Cache"))
+
+	// Responses come back in order with their own ids and results.
+	res := decodeBatch(t, w2)
+	if assert.Len(t, res.Responses, 2) {
+		assert.Equal(t, "1", res.Responses[0].GetID())
+		assert.Contains(t, string(res.Responses[0].Result), "eth_getBlockByHash")
+		assert.Equal(t, "2", res.Responses[1].GetID())
+		assert.Contains(t, string(res.Responses[1].Result), "eth_getTransactionReceipt")
+	}
+}
+
+// TestCache_BatchPartial: only the uncached / non-cacheable elements of a batch
+// are forwarded; cached elements are merged back in their original positions.
+func TestCache_BatchPartial(t *testing.T) {
+	ep, hits := cacheEndpoint(t, methodResult)
+
+	// Warm the cache for one read.
+	doRPC(ep, `{"jsonrpc":"2.0","id":9,"method":"eth_getBlockByHash","params":["0xh",false]}`)
+	assert.Equal(t, int64(1), hits.Load())
+
+	// Batch: [cached getBlockByHash, non-cacheable eth_blockNumber].
+	batch := `[{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByHash","params":["0xh",false]},` +
+		`{"jsonrpc":"2.0","id":2,"method":"eth_blockNumber","params":[]}]`
+	w := doRPC(ep, batch)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int64(2), hits.Load(), "only the non-cacheable element should reach upstream")
+
+	res := decodeBatch(t, w)
+	if assert.Len(t, res.Responses, 2) {
+		assert.Equal(t, "1", res.Responses[0].GetID(), "order preserved: cached element first")
+		assert.Contains(t, string(res.Responses[0].Result), "eth_getBlockByHash")
+		assert.Equal(t, "2", res.Responses[1].GetID())
+		assert.Contains(t, string(res.Responses[1].Result), "eth_blockNumber")
+	}
+}
+
+// TestCache_IncludeTransactionsInKey: eth_getBlockByNumber's second param
+// (includeTransactions) is part of the cache key, so true and false responses
+// are cached separately and never conflated.
+func TestCache_IncludeTransactionsInKey(t *testing.T) {
+	ep, hits := cacheEndpoint(t, func(req *rpc.Request) *rpc.Response {
+		return result(req, `"0xblock"`)
+	})
+	full := `{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["0x1234",true]}`
+	light := `{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["0x1234",false]}`
+
+	doRPC(ep, full)
+	doRPC(ep, full)
+	assert.Equal(t, int64(1), hits.Load(), "repeat of includeTransactions=true should hit cache")
+
+	doRPC(ep, light) // different includeTransactions -> distinct key -> upstream
+	assert.Equal(t, int64(2), hits.Load(), "includeTransactions=false must not reuse the true entry")
+	doRPC(ep, light)
+	assert.Equal(t, int64(2), hits.Load(), "repeat of includeTransactions=false should hit cache")
+}
+
+// TestCache_NonCacheableMethod: a method not on the allowlist is never cached.
+func TestCache_NonCacheableMethod(t *testing.T) {
+	ep, hits := cacheEndpoint(t, func(req *rpc.Request) *rpc.Response {
+		return result(req, `"0x10"`)
+	})
+	body := `{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}`
+	doRPC(ep, body)
+	doRPC(ep, body)
+	assert.Equal(t, int64(2), hits.Load(), "non-allowlisted method must not be cached")
+}

--- a/internal/chain/btc/btc.go
+++ b/internal/chain/btc/btc.go
@@ -30,13 +30,13 @@ var cacheable = map[string]struct{}{
 	"getblockhash":   {},
 }
 
-func (c *Chain) Cacheable(method string, _ json.RawMessage) bool {
+func (c *Chain) CacheableRequest(method string, _ json.RawMessage) bool {
 	_, ok := cacheable[method]
 	return ok
 }
 
-// CacheableResult caches any non-null, non-empty successful result.
-func (c *Chain) CacheableResult(_ string, result json.RawMessage) bool {
+// CacheableResponse caches any non-null, non-empty successful result.
+func (c *Chain) CacheableResponse(_ string, result json.RawMessage) bool {
 	trimmed := bytes.TrimSpace(result)
 	return len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("null"))
 }

--- a/internal/chain/btc/btc.go
+++ b/internal/chain/btc/btc.go
@@ -1,7 +1,9 @@
 package btc
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 
@@ -18,6 +20,26 @@ var genesisBlocks = map[string]string{
 }
 
 type Chain struct{}
+
+// cacheable is the allowlist of Bitcoin RPC methods whose responses may be
+// cached. Restricted to by-hash lookups whose result is immutable; verbose
+// getrawtransaction is excluded because its "confirmations" field changes.
+var cacheable = map[string]struct{}{
+	"getblock":       {},
+	"getblockheader": {},
+	"getblockhash":   {},
+}
+
+func (c *Chain) Cacheable(method string, _ json.RawMessage) bool {
+	_, ok := cacheable[method]
+	return ok
+}
+
+// CacheableResult caches any non-null, non-empty successful result.
+func (c *Chain) CacheableResult(_ string, result json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(result)
+	return len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("null"))
+}
 
 type networkInfo struct {
 	Subversion string `json:"subversion"`

--- a/internal/chain/btc/cache_test.go
+++ b/internal/chain/btc/cache_test.go
@@ -1,0 +1,31 @@
+package btc
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCacheable(t *testing.T) {
+	c := &Chain{}
+	for method, want := range map[string]bool{
+		"getblock":           true,
+		"getblockheader":     true,
+		"getblockhash":       true,
+		"getrawtransaction":  false,
+		"sendrawtransaction": false,
+	} {
+		if got := c.Cacheable(method, nil); got != want {
+			t.Errorf("Cacheable(%q) = %v, want %v", method, got, want)
+		}
+	}
+}
+
+func TestCacheableResult(t *testing.T) {
+	c := &Chain{}
+	if c.CacheableResult("getblock", json.RawMessage(`null`)) {
+		t.Error("null result must not be cacheable")
+	}
+	if !c.CacheableResult("getblock", json.RawMessage(`{"hash":"x"}`)) {
+		t.Error("non-null result should be cacheable")
+	}
+}

--- a/internal/chain/btc/cache_test.go
+++ b/internal/chain/btc/cache_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestCacheable(t *testing.T) {
+func TestCacheableRequest(t *testing.T) {
 	c := &Chain{}
 	for method, want := range map[string]bool{
 		"getblock":           true,
@@ -14,18 +14,18 @@ func TestCacheable(t *testing.T) {
 		"getrawtransaction":  false,
 		"sendrawtransaction": false,
 	} {
-		if got := c.Cacheable(method, nil); got != want {
-			t.Errorf("Cacheable(%q) = %v, want %v", method, got, want)
+		if got := c.CacheableRequest(method, nil); got != want {
+			t.Errorf("CacheableRequest(%q) = %v, want %v", method, got, want)
 		}
 	}
 }
 
-func TestCacheableResult(t *testing.T) {
+func TestCacheableResponse(t *testing.T) {
 	c := &Chain{}
-	if c.CacheableResult("getblock", json.RawMessage(`null`)) {
+	if c.CacheableResponse("getblock", json.RawMessage(`null`)) {
 		t.Error("null result must not be cacheable")
 	}
-	if !c.CacheableResult("getblock", json.RawMessage(`{"hash":"x"}`)) {
+	if !c.CacheableResponse("getblock", json.RawMessage(`{"hash":"x"}`)) {
 		t.Error("non-null result should be cacheable")
 	}
 }

--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -38,19 +38,19 @@ type Chain interface {
 	// ParseErrorResponse parses the error response from the provider and returns an error if the error should set the provider as unhealthy.
 	HandleError(code int, message string) error
 
-	// Cacheable reports whether a request (method + raw params) is eligible for
+	// CacheableRequest reports whether a request (method + raw params) is eligible for
 	// caching: a per-chain allowlist of read-only methods whose result is stable
 	// over a TTL, excluding params that reference mutable state (e.g. an EVM
 	// "latest"/"pending" block tag). Params are passed so each chain decides
 	// volatility in its own terms. This differs from coalesceability: a method
 	// may be safe to share between concurrent callers yet change too often to cache.
-	Cacheable(method string, params json.RawMessage) bool
+	CacheableRequest(method string, params json.RawMessage) bool
 
-	// CacheableResult reports whether a specific successful result for method may
+	// CacheableResponse reports whether a specific successful result for method may
 	// be stored. It guards results that are not yet immutable, e.g. an
 	// unconfirmed eth_getTransactionByHash (null blockNumber) or a null/missing
 	// lookup. result is the raw JSON of the response's "result" field.
-	CacheableResult(method string, result json.RawMessage) bool
+	CacheableResponse(method string, result json.RawMessage) bool
 }
 
 var (

--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/wille/haprovider/internal/chain/btc"
 	"github.com/wille/haprovider/internal/chain/eth"
@@ -36,6 +37,20 @@ type Chain interface {
 
 	// ParseErrorResponse parses the error response from the provider and returns an error if the error should set the provider as unhealthy.
 	HandleError(code int, message string) error
+
+	// Cacheable reports whether a request (method + raw params) is eligible for
+	// caching: a per-chain allowlist of read-only methods whose result is stable
+	// over a TTL, excluding params that reference mutable state (e.g. an EVM
+	// "latest"/"pending" block tag). Params are passed so each chain decides
+	// volatility in its own terms. This differs from coalesceability: a method
+	// may be safe to share between concurrent callers yet change too often to cache.
+	Cacheable(method string, params json.RawMessage) bool
+
+	// CacheableResult reports whether a specific successful result for method may
+	// be stored. It guards results that are not yet immutable, e.g. an
+	// unconfirmed eth_getTransactionByHash (null blockNumber) or a null/missing
+	// lookup. result is the raw JSON of the response's "result" field.
+	CacheableResult(method string, result json.RawMessage) bool
 }
 
 var (

--- a/internal/chain/eth/cache.go
+++ b/internal/chain/eth/cache.go
@@ -1,0 +1,77 @@
+package eth
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+// cacheable is the allowlist of EVM JSON-RPC methods whose responses may be
+// cached: read-only calls whose result is immutable for given params (subject to
+// the caller's block-tag guard and a TTL). Shared by the Ethereum and Tron
+// chains (Tron speaks the EVM JSON-RPC surface).
+var cacheable = map[string]struct{}{
+	"eth_chainId":                            {},
+	"net_version":                            {},
+	"web3_clientVersion":                     {},
+	"eth_getBlockByHash":                     {},
+	"eth_getBlockByNumber":                   {},
+	"eth_getBlockReceipts":                   {},
+	"eth_getTransactionByHash":               {},
+	"eth_getTransactionReceipt":              {},
+	"eth_getTransactionByBlockHashAndIndex":  {},
+	"eth_getUncleByBlockHashAndIndex":        {},
+	"eth_getBlockTransactionCountByHash":     {},
+}
+
+// mutableBlockTags are EVM block references whose target changes over time; a
+// response for a request referencing one must not be cached.
+var mutableBlockTags = []string{"latest", "pending", "safe", "finalized"}
+
+// Cacheable reports whether an EVM JSON-RPC request (method + params) may be
+// cached: the method must be on the allowlist and the params must not reference
+// a mutable block tag (latest/pending/safe/finalized). The tag check is
+// conservative: a false positive only costs a missed cache, never a stale answer.
+func Cacheable(method string, params json.RawMessage) bool {
+	if _, ok := cacheable[method]; !ok {
+		return false
+	}
+	s := string(params)
+	for _, tag := range mutableBlockTags {
+		if strings.Contains(s, `"`+tag+`"`) {
+			return false
+		}
+	}
+	return true
+}
+
+// CacheableResult reports whether a specific successful result may be stored.
+// Never caches a null/empty result (a missing block/tx or absent receipt). For
+// eth_getTransactionByHash it additionally requires the transaction to be
+// confirmed (non-null blockNumber): a pending transaction's response is not yet
+// immutable and would otherwise be cached with a null blockNumber.
+func CacheableResult(method string, result json.RawMessage) bool {
+	if isNullResult(result) {
+		return false
+	}
+	if method == "eth_getTransactionByHash" {
+		return hasNonNullField(result, "blockNumber")
+	}
+	return true
+}
+
+func isNullResult(result json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(result)
+	return len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null"))
+}
+
+// hasNonNullField reports whether the JSON object result has field set to a
+// non-null value.
+func hasNonNullField(result json.RawMessage, field string) bool {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(result, &obj); err != nil {
+		return false
+	}
+	v, ok := obj[field]
+	return ok && !bytes.Equal(bytes.TrimSpace(v), []byte("null"))
+}

--- a/internal/chain/eth/cache.go
+++ b/internal/chain/eth/cache.go
@@ -28,11 +28,11 @@ var cacheable = map[string]struct{}{
 // response for a request referencing one must not be cached.
 var mutableBlockTags = []string{"latest", "pending", "safe", "finalized"}
 
-// Cacheable reports whether an EVM JSON-RPC request (method + params) may be
+// CacheableRequest reports whether an EVM JSON-RPC request (method + params) may be
 // cached: the method must be on the allowlist and the params must not reference
 // a mutable block tag (latest/pending/safe/finalized). The tag check is
 // conservative: a false positive only costs a missed cache, never a stale answer.
-func Cacheable(method string, params json.RawMessage) bool {
+func CacheableRequest(method string, params json.RawMessage) bool {
 	if _, ok := cacheable[method]; !ok {
 		return false
 	}
@@ -45,12 +45,12 @@ func Cacheable(method string, params json.RawMessage) bool {
 	return true
 }
 
-// CacheableResult reports whether a specific successful result may be stored.
+// CacheableResponse reports whether a specific successful result may be stored.
 // Never caches a null/empty result (a missing block/tx or absent receipt). For
 // eth_getTransactionByHash it additionally requires the transaction to be
 // confirmed (non-null blockNumber): a pending transaction's response is not yet
 // immutable and would otherwise be cached with a null blockNumber.
-func CacheableResult(method string, result json.RawMessage) bool {
+func CacheableResponse(method string, result json.RawMessage) bool {
 	if isNullResult(result) {
 		return false
 	}

--- a/internal/chain/eth/cache_test.go
+++ b/internal/chain/eth/cache_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestCacheable(t *testing.T) {
+func TestCacheableRequest(t *testing.T) {
 	cases := []struct {
 		method string
 		params string
@@ -28,35 +28,35 @@ func TestCacheable(t *testing.T) {
 	}
 	c := &Ethereum{}
 	for _, tc := range cases {
-		if got := c.Cacheable(tc.method, json.RawMessage(tc.params)); got != tc.want {
-			t.Errorf("Cacheable(%q, %s) = %v, want %v", tc.method, tc.params, got, tc.want)
+		if got := c.CacheableRequest(tc.method, json.RawMessage(tc.params)); got != tc.want {
+			t.Errorf("CacheableRequest(%q, %s) = %v, want %v", tc.method, tc.params, got, tc.want)
 		}
 	}
 }
 
-func TestCacheableResult(t *testing.T) {
+func TestCacheableResponse(t *testing.T) {
 	c := &Ethereum{}
 
 	// null / empty results are never cached.
-	if c.CacheableResult("eth_getTransactionReceipt", json.RawMessage(`null`)) {
+	if c.CacheableResponse("eth_getTransactionReceipt", json.RawMessage(`null`)) {
 		t.Error("null result must not be cacheable")
 	}
-	if c.CacheableResult("eth_getBlockByHash", json.RawMessage(``)) {
+	if c.CacheableResponse("eth_getBlockByHash", json.RawMessage(``)) {
 		t.Error("empty result must not be cacheable")
 	}
 
 	// A non-null receipt (implies mined) is cacheable.
-	if !c.CacheableResult("eth_getTransactionReceipt", json.RawMessage(`{"status":"0x1"}`)) {
+	if !c.CacheableResponse("eth_getTransactionReceipt", json.RawMessage(`{"status":"0x1"}`)) {
 		t.Error("non-null receipt should be cacheable")
 	}
 
 	// eth_getTransactionByHash: pending (null blockNumber) not cacheable; confirmed is.
 	pending := json.RawMessage(`{"hash":"0xabc","blockNumber":null}`)
-	if c.CacheableResult("eth_getTransactionByHash", pending) {
+	if c.CacheableResponse("eth_getTransactionByHash", pending) {
 		t.Error("pending transaction (null blockNumber) must not be cacheable")
 	}
 	confirmed := json.RawMessage(`{"hash":"0xabc","blockNumber":"0x10"}`)
-	if !c.CacheableResult("eth_getTransactionByHash", confirmed) {
+	if !c.CacheableResponse("eth_getTransactionByHash", confirmed) {
 		t.Error("confirmed transaction should be cacheable")
 	}
 }

--- a/internal/chain/eth/cache_test.go
+++ b/internal/chain/eth/cache_test.go
@@ -1,0 +1,62 @@
+package eth
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCacheable(t *testing.T) {
+	cases := []struct {
+		method string
+		params string
+		want   bool
+	}{
+		{"eth_chainId", `[]`, true},
+		{"eth_getBlockByHash", `["0xhash",false]`, true},
+		{"eth_getBlockByNumber", `["0x1234",false]`, true},
+		{"eth_getTransactionByHash", `["0xtx"]`, true},
+		{"eth_getTransactionReceipt", `["0xtx"]`, true},
+		// not cacheable: mutable / state-dependent methods
+		{"eth_blockNumber", `[]`, false},
+		{"eth_getBalance", `["0xaddr","0x1"]`, false},
+		{"eth_getTransactionCount", `["0xaddr","0x1"]`, false},
+		{"eth_call", `[{}]`, false},
+		{"eth_sendRawTransaction", `["0xsigned"]`, false},
+		// allowlisted method but a mutable block tag in params: not cacheable
+		{"eth_getBlockByNumber", `["latest",false]`, false},
+		{"eth_getBlockByNumber", `["pending",false]`, false},
+	}
+	c := &Ethereum{}
+	for _, tc := range cases {
+		if got := c.Cacheable(tc.method, json.RawMessage(tc.params)); got != tc.want {
+			t.Errorf("Cacheable(%q, %s) = %v, want %v", tc.method, tc.params, got, tc.want)
+		}
+	}
+}
+
+func TestCacheableResult(t *testing.T) {
+	c := &Ethereum{}
+
+	// null / empty results are never cached.
+	if c.CacheableResult("eth_getTransactionReceipt", json.RawMessage(`null`)) {
+		t.Error("null result must not be cacheable")
+	}
+	if c.CacheableResult("eth_getBlockByHash", json.RawMessage(``)) {
+		t.Error("empty result must not be cacheable")
+	}
+
+	// A non-null receipt (implies mined) is cacheable.
+	if !c.CacheableResult("eth_getTransactionReceipt", json.RawMessage(`{"status":"0x1"}`)) {
+		t.Error("non-null receipt should be cacheable")
+	}
+
+	// eth_getTransactionByHash: pending (null blockNumber) not cacheable; confirmed is.
+	pending := json.RawMessage(`{"hash":"0xabc","blockNumber":null}`)
+	if c.CacheableResult("eth_getTransactionByHash", pending) {
+		t.Error("pending transaction (null blockNumber) must not be cacheable")
+	}
+	confirmed := json.RawMessage(`{"hash":"0xabc","blockNumber":"0x10"}`)
+	if !c.CacheableResult("eth_getTransactionByHash", confirmed) {
+		t.Error("confirmed transaction should be cacheable")
+	}
+}

--- a/internal/chain/eth/eth.go
+++ b/internal/chain/eth/eth.go
@@ -39,12 +39,12 @@ func (c *Ethereum) HandleError(code int, message string) error {
 	return nil
 }
 
-func (c *Ethereum) Cacheable(method string, params json.RawMessage) bool {
-	return Cacheable(method, params)
+func (c *Ethereum) CacheableRequest(method string, params json.RawMessage) bool {
+	return CacheableRequest(method, params)
 }
 
-func (c *Ethereum) CacheableResult(method string, result json.RawMessage) bool {
-	return CacheableResult(method, result)
+func (c *Ethereum) CacheableResponse(method string, result json.RawMessage) bool {
+	return CacheableResponse(method, result)
 }
 
 func (c Ethereum) ValidateConfig(e *core.Endpoint) error {

--- a/internal/chain/eth/eth.go
+++ b/internal/chain/eth/eth.go
@@ -2,6 +2,7 @@ package eth
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"strconv"
@@ -36,6 +37,14 @@ func (c *Ethereum) HandleError(code int, message string) error {
 	}
 
 	return nil
+}
+
+func (c *Ethereum) Cacheable(method string, params json.RawMessage) bool {
+	return Cacheable(method, params)
+}
+
+func (c *Ethereum) CacheableResult(method string, result json.RawMessage) bool {
+	return CacheableResult(method, result)
 }
 
 func (c Ethereum) ValidateConfig(e *core.Endpoint) error {

--- a/internal/chain/solana/cache_test.go
+++ b/internal/chain/solana/cache_test.go
@@ -1,0 +1,32 @@
+package solana
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCacheable(t *testing.T) {
+	c := &Chain{}
+	for method, want := range map[string]bool{
+		"getBlock":        true,
+		"getTransaction":  true,
+		"getGenesisHash":  true,
+		"getBalance":      false,
+		"sendTransaction": false,
+		"getBlockHeight":  false,
+	} {
+		if got := c.Cacheable(method, nil); got != want {
+			t.Errorf("Cacheable(%q) = %v, want %v", method, got, want)
+		}
+	}
+}
+
+func TestCacheableResult(t *testing.T) {
+	c := &Chain{}
+	if c.CacheableResult("getBlock", json.RawMessage(`null`)) {
+		t.Error("null result must not be cacheable")
+	}
+	if !c.CacheableResult("getBlock", json.RawMessage(`{"blockhash":"x"}`)) {
+		t.Error("non-null result should be cacheable")
+	}
+}

--- a/internal/chain/solana/cache_test.go
+++ b/internal/chain/solana/cache_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestCacheable(t *testing.T) {
+func TestCacheableRequest(t *testing.T) {
 	c := &Chain{}
 	for method, want := range map[string]bool{
 		"getBlock":        true,
@@ -15,18 +15,18 @@ func TestCacheable(t *testing.T) {
 		"sendTransaction": false,
 		"getBlockHeight":  false,
 	} {
-		if got := c.Cacheable(method, nil); got != want {
-			t.Errorf("Cacheable(%q) = %v, want %v", method, got, want)
+		if got := c.CacheableRequest(method, nil); got != want {
+			t.Errorf("CacheableRequest(%q) = %v, want %v", method, got, want)
 		}
 	}
 }
 
-func TestCacheableResult(t *testing.T) {
+func TestCacheableResponse(t *testing.T) {
 	c := &Chain{}
-	if c.CacheableResult("getBlock", json.RawMessage(`null`)) {
+	if c.CacheableResponse("getBlock", json.RawMessage(`null`)) {
 		t.Error("null result must not be cacheable")
 	}
-	if !c.CacheableResult("getBlock", json.RawMessage(`{"blockhash":"x"}`)) {
+	if !c.CacheableResponse("getBlock", json.RawMessage(`{"blockhash":"x"}`)) {
 		t.Error("non-null result should be cacheable")
 	}
 }

--- a/internal/chain/solana/solana.go
+++ b/internal/chain/solana/solana.go
@@ -1,7 +1,9 @@
 package solana
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 
@@ -29,6 +31,29 @@ func (c *Chain) ValidateConfig(e *core.Endpoint) error {
 	}
 
 	return nil
+}
+
+// cacheable is the allowlist of Solana JSON-RPC methods whose responses may be
+// cached. Kept modest; note commitment levels (processed/confirmed/finalized) in
+// params can affect freshness, so a TTL bounds staleness.
+var cacheable = map[string]struct{}{
+	"getGenesisHash": {},
+	"getVersion":     {},
+	"getBlock":       {},
+	"getTransaction": {},
+	"getBlockTime":   {},
+}
+
+func (c *Chain) Cacheable(method string, _ json.RawMessage) bool {
+	_, ok := cacheable[method]
+	return ok
+}
+
+// CacheableResult caches any non-null, non-empty successful result (a null
+// result means the block/transaction was not found).
+func (c *Chain) CacheableResult(_ string, result json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(result)
+	return len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("null"))
 }
 
 func (c *Chain) HandleError(code int, message string) error {

--- a/internal/chain/solana/solana.go
+++ b/internal/chain/solana/solana.go
@@ -44,14 +44,14 @@ var cacheable = map[string]struct{}{
 	"getBlockTime":   {},
 }
 
-func (c *Chain) Cacheable(method string, _ json.RawMessage) bool {
+func (c *Chain) CacheableRequest(method string, _ json.RawMessage) bool {
 	_, ok := cacheable[method]
 	return ok
 }
 
-// CacheableResult caches any non-null, non-empty successful result (a null
+// CacheableResponse caches any non-null, non-empty successful result (a null
 // result means the block/transaction was not found).
-func (c *Chain) CacheableResult(_ string, result json.RawMessage) bool {
+func (c *Chain) CacheableResponse(_ string, result json.RawMessage) bool {
 	trimmed := bytes.TrimSpace(result)
 	return len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("null"))
 }

--- a/internal/chain/tron/cache_test.go
+++ b/internal/chain/tron/cache_test.go
@@ -1,0 +1,18 @@
+package tron
+
+import "testing"
+
+// Tron delegates to the shared EVM policy.
+func TestCacheable(t *testing.T) {
+	c := &Chain{}
+	for method, want := range map[string]bool{
+		"eth_getBlockByHash":       true,
+		"eth_getTransactionByHash": true,
+		"eth_blockNumber":          false,
+		"eth_sendRawTransaction":   false,
+	} {
+		if got := c.Cacheable(method, nil); got != want {
+			t.Errorf("Cacheable(%q) = %v, want %v", method, got, want)
+		}
+	}
+}

--- a/internal/chain/tron/cache_test.go
+++ b/internal/chain/tron/cache_test.go
@@ -3,7 +3,7 @@ package tron
 import "testing"
 
 // Tron delegates to the shared EVM policy.
-func TestCacheable(t *testing.T) {
+func TestCacheableRequest(t *testing.T) {
 	c := &Chain{}
 	for method, want := range map[string]bool{
 		"eth_getBlockByHash":       true,
@@ -11,8 +11,8 @@ func TestCacheable(t *testing.T) {
 		"eth_blockNumber":          false,
 		"eth_sendRawTransaction":   false,
 	} {
-		if got := c.Cacheable(method, nil); got != want {
-			t.Errorf("Cacheable(%q) = %v, want %v", method, got, want)
+		if got := c.CacheableRequest(method, nil); got != want {
+			t.Errorf("CacheableRequest(%q) = %v, want %v", method, got, want)
 		}
 	}
 }

--- a/internal/chain/tron/tron.go
+++ b/internal/chain/tron/tron.go
@@ -2,6 +2,7 @@ package tron
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"strings"
@@ -31,6 +32,16 @@ func (c *Chain) HandleError(code int, message string) error {
 	}
 
 	return nil
+}
+
+// Cacheable and CacheableResult delegate to the shared EVM policy: Tron speaks
+// the EVM JSON-RPC surface.
+func (c *Chain) Cacheable(method string, params json.RawMessage) bool {
+	return eth.Cacheable(method, params)
+}
+
+func (c *Chain) CacheableResult(method string, result json.RawMessage) bool {
+	return eth.CacheableResult(method, result)
 }
 
 // Healthcheck batches the node-info RPCs (client version, chain id, block

--- a/internal/chain/tron/tron.go
+++ b/internal/chain/tron/tron.go
@@ -34,14 +34,14 @@ func (c *Chain) HandleError(code int, message string) error {
 	return nil
 }
 
-// Cacheable and CacheableResult delegate to the shared EVM policy: Tron speaks
+// CacheableRequest and CacheableResponse delegate to the shared EVM policy: Tron speaks
 // the EVM JSON-RPC surface.
-func (c *Chain) Cacheable(method string, params json.RawMessage) bool {
-	return eth.Cacheable(method, params)
+func (c *Chain) CacheableRequest(method string, params json.RawMessage) bool {
+	return eth.CacheableRequest(method, params)
 }
 
-func (c *Chain) CacheableResult(method string, result json.RawMessage) bool {
-	return eth.CacheableResult(method, result)
+func (c *Chain) CacheableResponse(method string, result json.RawMessage) bool {
+	return eth.CacheableResponse(method, result)
 }
 
 // Healthcheck batches the node-info RPCs (client version, chain id, block

--- a/internal/config.go
+++ b/internal/config.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/wille/haprovider/internal/cache"
 	"github.com/wille/haprovider/internal/chain"
 	"github.com/wille/haprovider/internal/core"
 	yaml "gopkg.in/yaml.v2"
@@ -55,6 +56,15 @@ func LoadConfig(configFile string) *Config {
 		}
 
 		if err := c.ValidateConfig(endpoint); err != nil {
+			panic(err)
+		}
+
+		// Attach an in-memory response cache to every endpoint by default.
+		var maxBytes int64
+		if endpoint.CacheMaxSizeMB != nil {
+			maxBytes = int64(*endpoint.CacheMaxSizeMB) * 1024 * 1024
+		}
+		if err := endpoint.InitCache(cache.NewMemory(maxBytes, 0)); err != nil {
 			panic(err)
 		}
 

--- a/internal/core/endpoint.go
+++ b/internal/core/endpoint.go
@@ -4,7 +4,15 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
+
+	"github.com/wille/haprovider/internal/cache"
 )
+
+// DefaultCacheTTL is the response-cache TTL applied when an endpoint does not
+// set cache_ttl. It is intentionally conservative to bound reorg staleness for
+// by-number/by-height lookups; tune per endpoint with cache_ttl.
+const DefaultCacheTTL = 10 * time.Second
 
 // DefaultMaxResponseSize bounds how large an upstream provider response may be
 // (HTTP body or WebSocket message) before we reject it, to protect the proxy
@@ -50,9 +58,54 @@ type Endpoint struct {
 	// Unset uses DefaultMaxResponseSize; 0 means unlimited.
 	MaxResponseSize *int64 `yaml:"max_response_size,omitempty"`
 
+	// CacheTTL is how long cacheable responses are kept. Unset uses
+	// DefaultCacheTTL; "0" (or any non-positive duration) disables caching for
+	// this endpoint. Parsed into cacheTTL by InitCache.
+	CacheTTL string `yaml:"cache_ttl,omitempty"`
+
+	// CacheMaxSizeMB is the total size budget in megabytes for this endpoint's
+	// response cache. Unset uses cache.DefaultMaxBytes.
+	CacheMaxSizeMB *int `yaml:"cache_max_size_mb,omitempty"`
+
+	// cache is the response-cache backend, attached at config load. cacheTTL is
+	// the parsed CacheTTL.
+	cache    cache.Storage
+	cacheTTL time.Duration
+
 	// mu guards ChainID, which is set/validated concurrently by per-provider
 	// healthcheck goroutines sharing this endpoint.
 	mu sync.Mutex
+}
+
+// InitCache parses the configured cache_ttl and attaches the given storage
+// backend. Called once at config load. Returns an error for an unparseable
+// cache_ttl.
+func (e *Endpoint) InitCache(store cache.Storage) error {
+	e.cacheTTL = DefaultCacheTTL
+	if e.CacheTTL != "" {
+		d, err := time.ParseDuration(e.CacheTTL)
+		if err != nil {
+			return fmt.Errorf("invalid cache_ttl %q: %w", e.CacheTTL, err)
+		}
+		e.cacheTTL = d
+	}
+	e.cache = store
+	return nil
+}
+
+// Cache returns the endpoint's response-cache backend (nil if unset).
+func (e *Endpoint) Cache() cache.Storage {
+	return e.cache
+}
+
+// GetCacheTTL returns the parsed cache TTL.
+func (e *Endpoint) GetCacheTTL() time.Duration {
+	return e.cacheTTL
+}
+
+// CacheEnabled reports whether response caching is active for this endpoint.
+func (e *Endpoint) CacheEnabled() bool {
+	return e.cache != nil && e.cacheTTL > 0
 }
 
 // SetChainID records the chain ID reported by a provider. The first provider to

--- a/internal/http.go
+++ b/internal/http.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
 
 	servertiming "github.com/mitchellh/go-server-timing"
+	"github.com/wille/haprovider/internal/cache"
 	"github.com/wille/haprovider/internal/chain"
 	"github.com/wille/haprovider/internal/core"
 	"github.com/wille/haprovider/internal/httpx"
@@ -67,6 +69,76 @@ func IncomingHttpRpcHandler(ctx context.Context, endpoint *core.Endpoint, w http
 		ctx = httpx.WithForwardedFor(ctx, r)
 	}
 
+	c := chain.New(endpoint.Kind)
+
+	// Cache plan: for each sub-request, serve cacheable hits from the cache and
+	// collect the rest (misses + non-cacheable) to forward upstream. This works
+	// for a single request and for every element of a batch independently.
+	cacheKeys := make([]string, len(req.Requests)) // "" = not cacheable, so not stored
+	responses := make([]*rpc.Response, len(req.Requests))
+	missIdx := make([]int, 0, len(req.Requests))
+
+	for i, sub := range req.Requests {
+		if endpoint.CacheEnabled() && c.Cacheable(sub.Method, sub.Params) {
+			key := cache.Key(sub.Method, sub.Params)
+			cacheKeys[i] = key
+			if val, ok, _ := endpoint.Cache().Get(ctx, key); ok {
+				metrics.RecordCacheHit(endpoint.Name, sub.Method)
+				responses[i] = &rpc.Response{Version: "2.0", ID: sub.ID, Result: val}
+				continue
+			}
+			metrics.RecordCacheMiss(endpoint.Name, sub.Method)
+		}
+		missIdx = append(missIdx, i)
+	}
+
+	// Everything was a cache hit: answer without contacting a provider.
+	if len(missIdx) == 0 {
+		log.Debug("cache hit", "batch", req.IsBatch, "size", len(req.Requests))
+		if !endpoint.Public {
+			w.Header().Set("X-Cache", "HIT")
+		}
+		writeBatch(w, &rpc.BatchResponse{Responses: responses, IsBatch: req.IsBatch}, log)
+		return
+	}
+
+	// Forward only the misses upstream, preserving the original request shape.
+	miss := &rpc.BatchRequest{IsBatch: req.IsBatch, Requests: make([]*rpc.Request, len(missIdx))}
+	for j, idx := range missIdx {
+		miss.Requests[j] = req.Requests[idx]
+	}
+
+	res, provider, err := forwardBatch(ctx, endpoint, c, miss, timing, log)
+	if err != nil {
+		writeForwardError(w, err, log)
+		return
+	}
+
+	// Store fresh cacheable results and merge the upstream responses back into
+	// their original positions.
+	for j, idx := range missIdx {
+		sub := res.Responses[j]
+		responses[idx] = sub
+		if cacheKeys[idx] != "" && !sub.IsError() && c.CacheableResult(req.Requests[idx].Method, sub.Result) {
+			_ = endpoint.Cache().Set(ctx, cacheKeys[idx], sub.Result, endpoint.GetCacheTTL())
+		}
+	}
+
+	if !endpoint.Public {
+		w.Header().Set("X-Provider", provider.Name)
+	}
+	writeBatch(w, &rpc.BatchResponse{Responses: responses, IsBatch: req.IsBatch}, log)
+}
+
+// errNoProvidersAvailable is returned by forwardBatch when no online provider
+// could serve the request.
+var errNoProvidersAvailable = errors.New("no providers available")
+
+// forwardBatch runs the provider failover loop for req and returns the first
+// successful response and the provider that produced it. It records per-request
+// metrics and marks providers unhealthy on failure. It returns ctx.Err() if the
+// context is cancelled mid-flight, or errNoProvidersAvailable when exhausted.
+func forwardBatch(ctx context.Context, endpoint *core.Endpoint, c chain.Chain, req *rpc.BatchRequest, timing *servertiming.Header, log *slog.Logger) (*rpc.BatchResponse, *core.Provider, error) {
 NextProvider:
 	for _, provider := range endpoint.Providers {
 		if !provider.IsOnline() {
@@ -82,7 +154,7 @@ NextProvider:
 		// Client connection closed
 		select {
 		case <-ctx.Done():
-			return
+			return nil, nil, ctx.Err()
 		default:
 		}
 
@@ -98,12 +170,12 @@ NextProvider:
 			continue NextProvider
 		}
 
-		log = log.With("provider", provider.Name, "request_time", time.Since(start).String())
-
-		if req.IsBatch {
-			log.Debug("batch request", "size", len(req.Requests))
-		} else {
-			log.Debug("request", "method", req.Requests[0].Method)
+		// A response must map one-to-one to the request; otherwise the merge back
+		// to the client is unsafe.
+		if len(res.Responses) != len(req.Requests) {
+			log.Error("batch response size mismatch", "request_size", len(req.Requests), "response_size", len(res.Responses))
+			provider.MarkUnhealthy(fmt.Errorf("batch response size mismatch"))
+			continue NextProvider
 		}
 
 		// Record one metric per (sub-)request, labeled by method, like the WS path.
@@ -117,51 +189,58 @@ NextProvider:
 			}
 		}
 
-		for _, res := range res.Responses {
-			if res.IsError() {
-				errorCode, errorMessage := res.GetError()
+		for _, sub := range res.Responses {
+			if sub.IsError() {
+				errorCode, errorMessage := sub.GetError()
 				log.Debug("error response", "error_code", errorCode, "error_message", errorMessage)
 
-				err := chain.New(endpoint.Kind).HandleError(errorCode, errorMessage.Error())
-
-				if err != nil {
-					provider.MarkUnhealthy(err)
+				if herr := c.HandleError(errorCode, errorMessage.Error()); herr != nil {
+					provider.MarkUnhealthy(herr)
 					continue NextProvider
 				}
 			}
 		}
 
-		if req.IsBatch && len(res.Responses) != len(req.Requests) {
-			log.Error("batch response size mismatch", "request_size", len(req.Requests), "response_size", len(res.Responses))
-			provider.MarkUnhealthy(fmt.Errorf("batch response size mismatch"))
-			continue NextProvider
-		}
+		log.With("provider", provider.Name, "request_time", time.Since(start).String()).Debug("forwarded")
+		return res, provider, nil
+	}
 
-		if !endpoint.Public {
-			w.Header().Set("X-Provider", provider.Name)
-		}
+	return nil, nil, errNoProvidersAvailable
+}
 
-		out, err := rpc.SerializeBatchResponse(res)
-		if err != nil {
-			log.Error("error serializing response", "error", err)
-			http.Error(w, "error serializing response", http.StatusInternalServerError)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-
-		if _, err := w.Write(out); err != nil {
-			log.Error("error writing body", "error", err)
-		}
-
+// writeForwardError writes the appropriate client response for a failover error.
+func writeForwardError(w http.ResponseWriter, err error, log *slog.Logger) {
+	// Client disconnected mid-flight: nothing left to write to.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return
 	}
 
-	log.Error("no providers available")
+	if errors.Is(err, errNoProvidersAvailable) {
+		log.Error("no providers available")
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		if werr := rpc.WriteResponse(w, &rpc.ErrorResponseNoProvidersAvailable); werr != nil {
+			log.Error("error writing body", "error", werr)
+		}
+		return
+	}
+
+	log.Error("request failed", "error", err)
+	http.Error(w, "request failed", http.StatusInternalServerError)
+}
+
+// writeBatch serializes and writes a batch response, setting the JSON content type.
+func writeBatch(w http.ResponseWriter, res *rpc.BatchResponse, log *slog.Logger) {
+	out, err := rpc.SerializeBatchResponse(res)
+	if err != nil {
+		log.Error("error serializing response", "error", err)
+		http.Error(w, "error serializing response", http.StatusInternalServerError)
+		return
+	}
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(http.StatusServiceUnavailable)
-	if err := rpc.WriteResponse(w, &rpc.ErrorResponseNoProvidersAvailable); err != nil {
+
+	if _, err := w.Write(out); err != nil {
 		log.Error("error writing body", "error", err)
 	}
 }

--- a/internal/http.go
+++ b/internal/http.go
@@ -79,7 +79,7 @@ func IncomingHttpRpcHandler(ctx context.Context, endpoint *core.Endpoint, w http
 	missIdx := make([]int, 0, len(req.Requests))
 
 	for i, sub := range req.Requests {
-		if endpoint.CacheEnabled() && c.Cacheable(sub.Method, sub.Params) {
+		if endpoint.CacheEnabled() && c.CacheableRequest(sub.Method, sub.Params) {
 			key := cache.Key(sub.Method, sub.Params)
 			cacheKeys[i] = key
 			if val, ok, _ := endpoint.Cache().Get(ctx, key); ok {
@@ -119,7 +119,7 @@ func IncomingHttpRpcHandler(ctx context.Context, endpoint *core.Endpoint, w http
 	for j, idx := range missIdx {
 		sub := res.Responses[j]
 		responses[idx] = sub
-		if cacheKeys[idx] != "" && !sub.IsError() && c.CacheableResult(req.Requests[idx].Method, sub.Result) {
+		if cacheKeys[idx] != "" && !sub.IsError() && c.CacheableResponse(req.Requests[idx].Method, sub.Result) {
 			_ = endpoint.Cache().Set(ctx, cacheKeys[idx], sub.Result, endpoint.GetCacheTTL())
 		}
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -69,6 +69,15 @@ var (
 		},
 		[]string{"endpoint", "transport"},
 	)
+
+	// Cache lookups, labeled by result (hit/miss).
+	cacheRequests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "haprovider_cache_requests_total",
+			Help: "Total number of cache lookups by result (hit/miss)",
+		},
+		[]string{"endpoint", "method", "result"},
+	)
 )
 
 // MetricsHandler returns an HTTP handler for the Prometheus metrics endpoint
@@ -80,7 +89,18 @@ func MetricsHandler() http.Handler {
 	prometheus.MustRegister(providerHealth)
 	prometheus.MustRegister(requestDuration)
 	prometheus.MustRegister(inflightRequests)
+	prometheus.MustRegister(cacheRequests)
 	return promhttp.Handler()
+}
+
+// RecordCacheHit records a cache hit for a request.
+func RecordCacheHit(endpoint, method string) {
+	cacheRequests.WithLabelValues(endpoint, method, "hit").Inc()
+}
+
+// RecordCacheMiss records a cache miss for a request.
+func RecordCacheMiss(endpoint, method string) {
+	cacheRequests.WithLabelValues(endpoint, method, "miss").Inc()
 }
 
 // TrackInflight increments the in-flight gauge and returns a function that

--- a/internal/ws/cache_test.go
+++ b/internal/ws/cache_test.go
@@ -1,0 +1,67 @@
+package ws
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/wille/haprovider/internal/cache"
+	"github.com/wille/haprovider/internal/core"
+	"github.com/wille/haprovider/internal/rpc"
+)
+
+// TestCache_WS: a cacheable request warms the cache; an identical follow-up on
+// the same connection is served from cache without a second upstream message.
+func TestCache_WS(t *testing.T) {
+	var upstreamMsgs atomic.Int64
+
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		for {
+			_, message, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			upstreamMsgs.Add(1)
+			batch, err := rpc.DecodeBatchRequest(message)
+			if err != nil {
+				continue
+			}
+			resps := make([]*rpc.Response, 0, len(batch.Requests))
+			for _, rq := range batch.Requests {
+				resps = append(resps, &rpc.Response{Version: "2.0", ID: rq.ID, Result: json.RawMessage(`"0xblock"`)})
+			}
+			out, _ := rpc.SerializeBatchResponse(&rpc.BatchResponse{Responses: resps, IsBatch: batch.IsBatch})
+			_ = conn.WriteMessage(websocket.TextMessage, out)
+		}
+	}))
+	t.Cleanup(up.Close)
+
+	p := &core.Provider{Name: "p", Ws: wsScheme(up.URL)}
+	ep := wsEndpoint(t, p)
+	if err := ep.InitCache(cache.NewMemory(0, 0)); err != nil {
+		t.Fatal(err)
+	}
+
+	c, _ := dial(t, proxyURL(t, ep))
+
+	// First request: forwarded upstream, its response cached.
+	sendRPC(t, c, "1", "eth_getBlockByHash")
+	assert.Equal(t, "0xblock", resultString(t, readRPC(t, c)))
+
+	// Second identical request (different id): served from cache.
+	sendRPC(t, c, "2", "eth_getBlockByHash")
+	res2 := readRPC(t, c)
+	assert.Equal(t, "0xblock", resultString(t, res2))
+	assert.Equal(t, "2", res2.GetID(), "cache hit must echo the caller's id")
+
+	assert.Equal(t, int64(1), upstreamMsgs.Load(), "second identical WS request should be served from cache")
+}

--- a/internal/ws/ws.go
+++ b/internal/ws/ws.go
@@ -9,10 +9,12 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
 	servertiming "github.com/mitchellh/go-server-timing"
+	"github.com/wille/haprovider/internal/cache"
 	"github.com/wille/haprovider/internal/chain"
 	"github.com/wille/haprovider/internal/core"
 	"github.com/wille/haprovider/internal/httpx"
@@ -70,6 +72,20 @@ type WebSocketProxy struct {
 	Responses chan *rpc.Response
 
 	badRequests int
+
+	// chain is the endpoint's chain implementation, used for cacheability checks.
+	chain chain.Chain
+
+	// pendingCache maps the JSON-RPC id of a forwarded cacheable request to the
+	// cache key/method to store its response under when it arrives. Written by
+	// pumpClient and read/cleared by pumpProvider, so guarded by cacheMu.
+	cacheMu      sync.Mutex
+	pendingCache map[string]pendingCacheEntry
+}
+
+type pendingCacheEntry struct {
+	key    string
+	method string
 }
 
 // Close destroys the proxy connection.
@@ -219,9 +235,60 @@ func (proxy *WebSocketProxy) pumpProvider(providerClient *Client) {
 				}
 			}
 
+			proxy.maybeCacheResponse(rpcResponse)
 			proxy.Responses <- rpcResponse
 		}
 	}
+}
+
+// maybeCacheResponse stores a successful response for a previously-forwarded
+// cacheable request (tracked by id in pendingCache), if the chain deems the
+// result cacheable.
+func (proxy *WebSocketProxy) maybeCacheResponse(res *rpc.Response) {
+	if !proxy.endpoint.CacheEnabled() || res.IsError() {
+		return
+	}
+
+	id := res.GetID()
+	proxy.cacheMu.Lock()
+	entry, ok := proxy.pendingCache[id]
+	if ok {
+		delete(proxy.pendingCache, id)
+	}
+	proxy.cacheMu.Unlock()
+
+	if !ok {
+		return
+	}
+	if proxy.chain.CacheableResult(entry.method, res.Result) {
+		_ = proxy.endpoint.Cache().Set(proxy.ctx, entry.key, res.Result, proxy.endpoint.GetCacheTTL())
+	}
+}
+
+// serveFromCache serves req from cache if possible. It returns true when a cache
+// hit was queued to the client (the request must not be forwarded). On a
+// cacheable miss it records the pending id→key mapping so the eventual response
+// is stored, and returns false so the caller forwards the request.
+func (proxy *WebSocketProxy) serveFromCache(req *rpc.Request) bool {
+	if !proxy.endpoint.CacheEnabled() || !proxy.chain.Cacheable(req.Method, req.Params) {
+		return false
+	}
+
+	key := cache.Key(req.Method, req.Params)
+	if val, ok, _ := proxy.endpoint.Cache().Get(proxy.ctx, key); ok {
+		metrics.RecordCacheHit(proxy.endpoint.Name, req.Method)
+		// Write straight to the client rather than via proxy.Responses: this runs
+		// on the pumpClient goroutine, which is also the sole consumer of
+		// proxy.Responses, so sending there could deadlock on a full buffer.
+		proxy.writeResponse(&rpc.Response{Version: "2.0", ID: req.ID, Result: val})
+		return true
+	}
+
+	metrics.RecordCacheMiss(proxy.endpoint.Name, req.Method)
+	proxy.cacheMu.Lock()
+	proxy.pendingCache[req.ID.String()] = pendingCacheEntry{key: key, method: req.Method}
+	proxy.cacheMu.Unlock()
+	return false
 }
 
 func (proxy *WebSocketProxy) pumpClient(client *Client) {
@@ -267,6 +334,12 @@ func (proxy *WebSocketProxy) pumpClient(client *Client) {
 
 			// Break up any batched requests into one request per message
 			for i, r := range req.Requests {
+				// Serve from cache when possible; otherwise forward upstream.
+				if proxy.serveFromCache(r) {
+					requestLog.With("rpc_id", r.GetID(), "method", r.Method).Debug("cache hit")
+					continue
+				}
+
 				proxy.Requests <- r
 
 				if req.IsBatch {
@@ -342,12 +415,14 @@ func IncomingWebsocketHandler(ctx context.Context, endpoint *core.Endpoint, w ht
 	ctx, cancel := context.WithCancelCause(ctx)
 
 	proxy := &WebSocketProxy{
-		log:           endpoint.Logger().With("ip", r.RemoteAddr, "transport", "ws"),
-		ctx:           ctx,
-		cancel:        cancel,
-		endpoint:      endpoint,
-		Responses: make(chan *rpc.Response, 32),
-		Requests:  make(chan *rpc.Request, 32),
+		log:          endpoint.Logger().With("ip", r.RemoteAddr, "transport", "ws"),
+		ctx:          ctx,
+		cancel:       cancel,
+		endpoint:     endpoint,
+		Responses:    make(chan *rpc.Response, 32),
+		Requests:     make(chan *rpc.Request, 32),
+		chain:        chain.New(endpoint.Kind),
+		pendingCache: make(map[string]pendingCacheEntry),
 	}
 
 	// Dial any provider before upgrading the websocket

--- a/internal/ws/ws.go
+++ b/internal/ws/ws.go
@@ -260,7 +260,7 @@ func (proxy *WebSocketProxy) maybeCacheResponse(res *rpc.Response) {
 	if !ok {
 		return
 	}
-	if proxy.chain.CacheableResult(entry.method, res.Result) {
+	if proxy.chain.CacheableResponse(entry.method, res.Result) {
 		_ = proxy.endpoint.Cache().Set(proxy.ctx, entry.key, res.Result, proxy.endpoint.GetCacheTTL())
 	}
 }
@@ -270,7 +270,7 @@ func (proxy *WebSocketProxy) maybeCacheResponse(res *rpc.Response) {
 // cacheable miss it records the pending id→key mapping so the eventual response
 // is stored, and returns false so the caller forwards the request.
 func (proxy *WebSocketProxy) serveFromCache(req *rpc.Request) bool {
-	if !proxy.endpoint.CacheEnabled() || !proxy.chain.Cacheable(req.Method, req.Params) {
+	if !proxy.endpoint.CacheEnabled() || !proxy.chain.CacheableRequest(req.Method, req.Params) {
 		return false
 	}
 


### PR DESCRIPTION
## What

Adds a response cache so repeat reads of immutable data (a block by hash, a mined receipt, `eth_chainId`) are served locally instead of hitting an upstream provider. This cuts provider load, latency, and rate-limit (429) exposure.

Enabled by default on every endpoint, using an in-memory store, on both the HTTP JSON-RPC and WebSocket paths.

## Correctness model

A response is cached only when all three layers agree:

1. **Method allowlist** — `chain.Cacheable(method, params)`, a per-chain set of read-only methods (EVM list shared by eth + tron; solana and btc have their own). Distinct from coalesceability: `eth_getTransactionCount` / `eth_blockNumber` are safe to share between concurrent callers but change too often to cache.
2. **Param volatility** — decided at the chain level: EVM refuses to cache requests referencing a mutable block tag (`latest`/`pending`/`safe`/`finalized`).
3. **Response guard** — `chain.CacheableResult(method, result)`: never caches error or null results, and skips an unconfirmed `eth_getTransactionByHash` (null `blockNumber`) until it is mined.

A per-entry TTL bounds residual reorg staleness.

## Storage

New `internal/cache` package with a pluggable `Storage` interface (the seam for a future Redis/etc. backend) and a default in-memory implementation:

- **Bounded LRU** capped by both a total byte budget and an entry count; evicts least-recently-used on either limit. O(1) ops.
- **5 MB per-response cap** — larger payloads (e.g. a full block with all transactions on a high-throughput chain) pass through uncached so one payload can't dominate the cache.
- Lazy expiry on read plus a background janitor bounded by the entry limit.

## Integration

- **HTTP** — caching is per sub-request, so it works for single requests and batches: cached members are served locally and only the misses are forwarded, then responses are merged back in order. An all-cached batch never contacts a provider. `X-Cache: HIT` on fully-cached responses.
- **WebSocket** — each (split) request is looked up in the cache; hits are answered without forwarding, and misses are stored when their response arrives.
- **Healthchecks are never cached** — they call the provider directly, bypassing the handler layer where the cache lives, so they always see fresh block/sync data.
- New `haprovider_cache_requests_total{endpoint,method,result}` metric.

## Configuration

Per endpoint (all optional; caching is on by default):

- `cache_ttl` — how long entries live (default `10s`; `0` disables caching).
- `cache_max_size_mb` — total cache byte budget (default `128`).

## Performance

Benchmarks included. The cache read is effectively free relative to request handling; the win is skipping the network:

- `MemoryGet` (hit): **84 ns/op, 0 allocs**
- End-to-end cache hit: **~30 us/op** vs **~275 us** against a localhost upstream (~9x; far more against a real remote provider), with zero upstream load.

The one scaling ceiling: `Get` takes the full mutex (LRU reordering is a write), so concurrent reads on a single endpoint serialize at ~1.7M hits/sec. Well above typical throughput; shardable behind the `Storage` interface if ever needed.

## Testing

- Unit: `Cacheable`/`CacheableResult` per chain (incl. pending vs confirmed tx), LRU eviction by bytes and by count, 5 MB cap, byte accounting, TTL expiry, and a concurrent (`-race`) test asserting the budget holds.
- HTTP integration: hit-after-miss, id echo, `latest`/null/error/non-allowlisted never cached, `includeTransactions` distinguishes entries, batch fully-cached and partial-forward-with-merge.
- WebSocket integration: warm cache served without a second upstream message.
- Full suite green under `-race`; `go vet` and `golangci-lint` clean.

## Scope / non-goals

- Non-memory `Storage` backends (Redis, etc.).
- Per-method / finality-aware TTL tiers.
- The TRON native HTTP API path (JSON-RPC only).